### PR TITLE
Try monkeypatch

### DIFF
--- a/tests/beam/transforms/test_pubsub.py
+++ b/tests/beam/transforms/test_pubsub.py
@@ -2,11 +2,12 @@ import pytest
 
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that, equal_to
+from apache_beam.io.gcp import pubsub
 
 from gfw.common.beam.transforms import ReadAndDecodeFromPubSub, FakeReadFromPubSub
 
 
-def test_read_and_decode_from_pubsub():
+def test_read_and_decode_from_pubsub(monkeypatch):
     """Test ReadAndDecodeFromPubSub with mocked PubSub input and UTF-8 decoding."""
 
     pubsub_messages = [
@@ -16,6 +17,8 @@ def test_read_and_decode_from_pubsub():
         )
     ]
 
+    monkeypatch.setattr(pubsub, "ReadFromPubSub", FakeReadFromPubSub)
+
     with TestPipeline() as p:
         output = (
             p
@@ -24,7 +27,7 @@ def test_read_and_decode_from_pubsub():
                 project="test-project",
                 decode=True,
                 decode_method="utf-8",
-                read_from_pubsub_factory=FakeReadFromPubSub,
+                # read_from_pubsub_factory=FakeReadFromPubSub,
                 messages=pubsub_messages,
             )
         )


### PR DESCRIPTION
Here I try to use monkeypatch in the test, instead of dependency injection. 

First problem I got: Patching strongly depends on import order. If you already imported before the code you want to patch, the patch is not going to work. For that I was forced to:
  1. Remove the Fake object from the module of the PTransform.
  2. Defer the import of the patched object to be after the patch.
  3. Add an additional import in other test function I had.

Even doing all of that, the test worked but the full test suite failed, because if other tests are also importing the object you want to patch, then the patch fails again. See [monkeypatch doesn't patch a module if it has already been imported by production code. #2229](https://github.com/pytest-dev/pytest/issues/2229).

Finally, the solution I found was to change the import in pubsub module from:
```python
from apache_beam.io.gcp.pubsub import PubsubMessage, ReadFromPubSub
```
to:
```python
import apache_beam.io.gcp.pubsub as pubsub
```
And access each resource individually. 


This is a simple case, but to me the clearest downsides are:
- The dependency is implicit rather than explicitly documented as a parameter of the class.
- A change in import order can break the test — or worse, silently prevent the patch from being applied without you noticing.
