### PR TITLE
Add ApplySlidingWindows PTransform

### DIFF
--- a/src/gfw/common/beam/transforms/__init__.py
+++ b/src/gfw/common/beam/transforms/__init__.py
@@ -16,6 +16,7 @@ These components aim to serve as building blocks to accelerate development while
 maintaining high code quality and reducing duplication.
 """
 
+from .apply_sliding_windows import ApplySlidingWindows
 from .bigquery_write_to_partitioned import FakeWriteToBigQuery, WriteToPartitionedBigQuery
 from .group_by import GroupBy
 from .pubsub import FakeReadFromPubSub, ReadAndDecodeFromPubSub
@@ -23,6 +24,7 @@ from .sample_and_log import SampleAndLogElements
 
 
 __all__ = [
+    "ApplySlidingWindows",
     "FakeReadFromPubSub",
     "FakeWriteToBigQuery",
     "GroupBy",

--- a/src/gfw/common/beam/transforms/apply_sliding_windows.py
+++ b/src/gfw/common/beam/transforms/apply_sliding_windows.py
@@ -1,0 +1,69 @@
+"""Transforms for applying sliding windows in Apache Beam."""
+
+from typing import Any, Dict
+
+import apache_beam as beam
+
+from apache_beam.pvalue import PCollection
+from apache_beam.transforms.window import SlidingWindows, TimestampedValue
+
+
+class ApplySlidingWindows(beam.PTransform):
+    """A PTransform that applies sliding windows to a PCollection.
+
+    Optionally assigns event-time timestamps based on a configurable field
+    before applying the windowing strategy.
+
+    Args:
+        period:
+            The window period (interval between window start times), in seconds.
+
+        offset:
+            The offset to apply to window start times, in seconds.
+
+        assign_timestamps:
+            Whether to assign timestamps using a field from each element.
+
+        timestamp_field:
+            The name of the field containing the timestamp (UNIX time, in seconds).
+
+        **kwargs:
+            Additional keyword arguments passed to base PTransform class.
+    """
+
+    def __init__(
+        self,
+        period: float,
+        offset: float,
+        assign_timestamps: bool = False,
+        timestamp_field: str = "timestamp",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._period = period
+        self._offset = offset
+        self._assign_timestamps = assign_timestamps
+        self._timestamp_field = timestamp_field
+
+    def expand(self, pcoll: PCollection[Dict[str, Any]]) -> PCollection[Dict[str, Any]]:
+        """Apply sliding windows to the input PCollection.
+
+        Optionally assigns event-time timestamps using the configured timestamp field.
+
+        Args:
+            pcoll:
+                A PCollection of dictionaries containing a timestamp field.
+
+        Returns:
+            A windowed PCollection with sliding windows applied.
+        """
+        size = self._period + self._offset
+
+        if self._assign_timestamps:
+            pcoll = pcoll | "AddTimestamps" >> beam.Map(
+                lambda e: TimestampedValue(e, e[self._timestamp_field])
+            )
+
+        return pcoll | "ApplySlidingWindows" >> beam.WindowInto(
+            SlidingWindows(size=size, period=self._period, offset=self._offset)
+        )

--- a/tests/beam/transforms/test_apply_sliding_windows.py
+++ b/tests/beam/transforms/test_apply_sliding_windows.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+import apache_beam as beam
+from apache_beam.transforms.window import SlidingWindows
+from apache_beam.testing.util import assert_that, equal_to
+from apache_beam.testing.test_pipeline import TestPipeline as _TestPipeline
+
+from gfw.common.beam.transforms import ApplySlidingWindows
+
+
+def test_sliding_windows_without_timestamp_assignment():
+    elements = [
+        {"id": 1, "value": 10},
+        {"id": 2, "value": 20},
+    ]
+
+    with _TestPipeline() as p:
+        pcoll = p | beam.Create(elements)
+
+        # Apply sliding windows without assigning timestamps
+        windowed = pcoll | ApplySlidingWindows(period=5, offset=0, assign_timestamps=False)
+
+        # Just verify elements pass through unchanged (windowing itself doesn't filter)
+        assert_that(windowed, equal_to(elements))
+
+
+def test_sliding_windows_with_timestamp_assignment():
+    elements = [
+        {"id": 1, "timestamp": 100, "value": 10},
+        {"id": 2, "timestamp": 105, "value": 20},
+    ]
+
+    with _TestPipeline() as p:
+        pcoll = p | beam.Create(elements)
+
+        windowed = pcoll | ApplySlidingWindows(period=5, offset=0, assign_timestamps=True)
+
+        # Check that output contains the original elements (windowing does not modify data)
+        assert_that(windowed, equal_to(elements))
+
+
+def test_sliding_windows_calls_slidingwindows_correctly():
+    period = 5
+    offset = 1
+    assign_timestamps = False
+
+    transform = ApplySlidingWindows(
+        period=period,
+        offset=offset,
+        assign_timestamps=assign_timestamps
+    )
+
+    # Dummy PCollection that supports | operator
+    class DummyPColl:
+        def __or__(self, other):
+            # When WindowInto is applied, return a marker string
+            return "windowed_pcoll"
+
+    dummy_pcoll = DummyPColl()
+
+    with patch("apache_beam.WindowInto") as mock_window_into:
+        result = transform.expand(dummy_pcoll)
+
+        mock_window_into.assert_called_once()
+        sliding_window_instance = mock_window_into.call_args[0][0]
+
+        assert isinstance(sliding_window_instance, SlidingWindows)
+        assert sliding_window_instance.period == period
+        assert sliding_window_instance.offset == offset
+        assert sliding_window_instance.size == period + offset
+        assert result == "windowed_pcoll"


### PR DESCRIPTION
### Add `ApplySlidingWindows` PTransform

This PR adds `ApplySlidingWindows`, a wrapper around Beam's `SlidingWindows` PTransform.

It optionally assigns event-time timestamps based on a configurable field before applying the sliding windowing strategy. Useful for pipelines where input elements need timestamp extraction prior to windowing.
#### Example usage

```python
windowed = records | ApplySlidingWindows(
    period=60,
    offset=10,
    assign_timestamps=True,
    timestamp_field="timestamp",
)
```

https://globalfishingwatch.atlassian.net/browse/PIPELINE-2807