### PR TITLE
Add GroupBy PTransform

### DIFF
--- a/src/gfw/common/beam/transforms/__init__.py
+++ b/src/gfw/common/beam/transforms/__init__.py
@@ -17,6 +17,7 @@ maintaining high code quality and reducing duplication.
 """
 
 from .bigquery_write_to_partitioned import FakeWriteToBigQuery, WriteToPartitionedBigQuery
+from .group_by import GroupBy
 from .pubsub import FakeReadFromPubSub, ReadAndDecodeFromPubSub
 from .sample_and_log import SampleAndLogElements
 
@@ -24,6 +25,7 @@ from .sample_and_log import SampleAndLogElements
 __all__ = [
     "FakeReadFromPubSub",
     "FakeWriteToBigQuery",
+    "GroupBy",
     "ReadAndDecodeFromPubSub",
     "SampleAndLogElements",
     "WriteToPartitionedBigQuery",

--- a/src/gfw/common/beam/transforms/group_by.py
+++ b/src/gfw/common/beam/transforms/group_by.py
@@ -1,0 +1,93 @@
+"""Custom Apache Beam GroupBy transform with automatic labeling.
+
+This module defines a wrapper around Beam's native `GroupBy` PTransform that adds
+a dynamically generated label based on the grouping keys. This helps improve
+pipeline readability and simplifies debugging, especially in Dataflow graphs
+where stage names are important for traceability.
+"""
+
+import logging
+
+from operator import itemgetter
+from typing import Any, Sequence
+
+import apache_beam as beam
+
+from apache_beam.pvalue import PCollection
+
+
+logger = logging.getLogger(__name__)
+
+
+class GroupBy(beam.PTransform):
+    """A labeled wrapper around Apache Beam's `GroupBy` transform for grouping by keys.
+
+    This transform wraps Beam's native `GroupBy` and adds an automatically generated
+    label based on the grouping keys. For example, grouping by `["user", "country"]`
+    with `elements="Sessions"` results in a label like `"GroupSessionsByUserAndCountry"`.
+
+    If `dict_fields=True` (default), string positional fields are interpreted as dictionary keys
+    and wrapped with `operator.itemgetter`. If False, strings are treated as attribute names.
+
+    Example:
+    pcoll | GroupBy("user", "country", elements="Sessions")
+
+    Args:
+        *fields:
+            Positional key fields to group by. If these are strings and `dict_fields=True`,
+            they will be interpreted as dictionary keys.
+
+        elements:
+            A human-readable label describing the grouped elements (e.g., "Messages" or
+            "Sessions"). It is used to generate the step label.
+
+        dict_fields:
+            If True (default), string fields are interpreted as dictionary keys and
+            wrapped with `itemgetter`. Set to False to use Beam's default behavior
+            (attribute access).
+
+        **kwargs:
+            Same as beam.GroupBy interface.
+    """
+
+    def __init__(
+        self, *fields: Any, elements: str = "", dict_fields: bool = True, **kwargs: Any
+    ) -> None:
+        self._fields = fields
+        self._elements = elements
+        self._dict_fields = dict_fields
+        self._kwargs = kwargs
+
+        if self._dict_fields:
+            self._kwargs.update({k: itemgetter(k) for k in self._fields})
+            self._fields = ()
+
+        keys = list(self._fields) + list(self._kwargs.keys())
+        super().__init__(label=self.create_label(keys, elements))
+
+    @classmethod
+    def create_label(cls, keys: Sequence[str], elements: str) -> str:
+        """Generate a descriptive label for the GroupBy transform based on keys and elements.
+
+        Constructs a label string combining the human-readable element description and
+        the grouping keys, formatted in a CamelCase style joined by 'And'.
+
+        For example, keys ['user', 'country'] and elements 'Sessions' result in
+        'GroupSessionsByUserAndCountry'.
+
+        Args:
+            keys:
+                A sequence of key field names used for grouping.
+
+            elements:
+                A human-readable label describing the grouped elements.
+
+        Returns:
+            A formatted string label for use as the PTransform's step label.
+        """
+        key_label = "And".join(s.title() for s in keys)
+        return f"Group{elements}By{key_label}"
+
+    def expand(self, pcoll: PCollection) -> PCollection:
+        """Applies the wrapped Beam GroupBy transform to the input PCollection."""
+        return pcoll | beam.GroupBy(*self._fields, **self._kwargs)

--- a/tests/beam/transforms/test_group_by.py
+++ b/tests/beam/transforms/test_group_by.py
@@ -1,0 +1,61 @@
+import pytest
+
+import apache_beam as beam
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that, equal_to
+
+from gfw.common.beam.transforms import GroupBy
+
+
+@pytest.mark.parametrize(
+    "keys, custom_label, expected_label",
+    [
+        pytest.param(
+            ["city", "country"], "", "GroupByCityAndCountry",
+            id="without-elements-label"
+        ),
+        pytest.param(
+            ["city", "country"], "Users", "GroupUsersByCityAndCountry",
+            id="with-elements-label"
+        )
+    ],
+)
+def test_groupby_label(keys, custom_label, expected_label):
+    transform = GroupBy(*keys, elements=custom_label)
+    assert transform.label == expected_label
+
+
+def test_groupby_groups_elements_correctly():
+    input_data = [
+        {"user": "alice", "country": "US", "value": 1},
+        {"user": "bob", "country": "US", "value": 2},
+        {"user": "alice", "country": "CA", "value": 3},
+        {"user": "alice", "country": "US", "value": 4},
+    ]
+
+    expected = [
+        {"user": "alice", "country": "US", "value": [1, 4]},
+        {"user": "bob", "country": "US", "value": [2]},
+        {"user": "alice", "country": "CA", "value": [3]},
+    ]
+
+    with TestPipeline() as p:
+        pcoll = p | beam.Create(input_data)
+
+        # Apply GroupBy on keys 'user' and 'country'
+        grouped = pcoll | GroupBy("user", "country")
+
+        # Now transform grouped elements to a uniform format for checking:
+        # grouped elements have keys plus grouped fields as lists (Beam groups automatically)
+
+        def format_group(grouped):
+            key, elements = grouped
+            return {
+                "user": key.user,
+                "country": key.country,
+                "value": sorted(e["value"] for e in elements),
+            }
+
+        formatted = grouped | beam.Map(format_group)
+
+        assert_that(formatted, equal_to(expected))


### PR DESCRIPTION
### Add custom GroupBy wrapper with automatic labeling

- Introduces a `GroupBy` PTransform wrapper around Beam's native `GroupBy`.
- Automatically generates descriptive labels based on grouping keys and element descriptions.
- Supports convenient dictionary key access by default (`dict_fields=True`).

The goal here is to improves readability and debugging of Dataflow pipeline graphs by providing meaningful step names.
