### PR TITLE
PIPELINE-2937: Add ReadMatchingAvroFiles PTransform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ test = [
   "pytest~=8.3",            # Core testing framework
   "pytest-cov~=6.0",        # Coverage plugin for pytest
   "pytest-mock~=3.14",      # Mocking plugin for pytest
+  "avro~=1.12",             # To create test data"
 ]
 
 # Development workflow and tools

--- a/src/gfw/common/beam/transforms/__init__.py
+++ b/src/gfw/common/beam/transforms/__init__.py
@@ -20,6 +20,7 @@ from .apply_sliding_windows import ApplySlidingWindows
 from .bigquery_write_to_partitioned import FakeWriteToBigQuery, WriteToPartitionedBigQuery
 from .group_by import GroupBy
 from .pubsub import FakeReadFromPubSub, ReadAndDecodeFromPubSub
+from .read_matching_avro_files import ReadMatchingAvroFiles
 from .sample_and_log import SampleAndLogElements
 
 
@@ -29,6 +30,7 @@ __all__ = [
     "FakeWriteToBigQuery",
     "GroupBy",
     "ReadAndDecodeFromPubSub",
+    "ReadMatchingAvroFiles",
     "SampleAndLogElements",
     "WriteToPartitionedBigQuery",
 ]

--- a/src/gfw/common/beam/transforms/read_matching_avro_files.py
+++ b/src/gfw/common/beam/transforms/read_matching_avro_files.py
@@ -1,0 +1,180 @@
+"""Module containing an Apache Beam transform for reading Avro files with datetime filtering."""
+
+import codecs
+import logging
+
+from datetime import timedelta
+from typing import Any, Optional, Sequence
+
+import apache_beam as beam
+
+from apache_beam.io import fileio
+from apache_beam.io.avroio import ReadAllFromAvro
+from apache_beam.pvalue import PCollection
+
+from gfw.common.datetime import datetime_from_string, get_datetime_from_string
+
+
+logger = logging.getLogger(__name__)
+
+
+class ReadMatchingAvroFiles(beam.PTransform):
+    """A generic PTransform to filter and read Avro files from any Beam-supported filesystem.
+
+    This transform's primary function is to intelligently filter filenames
+    based on a time range. It works by:
+
+    1. **Generating Date-based Patterns**: It first generates a list of file
+       patterns for each day within the specified `start_dt` and `end_dt`. This
+       efficiently prunes the search space for large, time-partitioned datasets.
+
+    2. **Precise Datetime Filtering**: After matching the daily patterns, it
+       applies a second, more precise filter to ensure that only files with a
+       timestamp strictly within the `start_dt` and `end_dt` are processed.
+
+    This PTransform is a generic and reusable component for any data pipeline
+    that needs to perform historical data backfills on time-partitioned Avro files.
+
+    Args:
+        base_path:
+            The base path to the Avro files. This can be a local directory
+            (e.g., '/path/to/data'), a GCS bucket (e.g., 'gs://my-bucket/'),
+            or any other Beam-supported filesystem path. The transform will
+            append a date-based wildcard pattern to this path.
+
+        start_dt:
+            The start datetime of the range, in ISO format (e.g., 'YYYY-MM-DDTHH:MM:SS').
+
+        end_dt:
+            The end datetime of the range, in ISO format (e.g., 'YYYY-MM-DDTHH:MM:SS').
+            Datetimes equal to this value are considered outside the range.
+
+        path_template:
+            Path template pointing to the folder containing the avro files.
+            Since it is assumed that the data is stored in date-partitioned folders,
+            it must include a 'date' placeholder (e.g., "nmea-{date}").
+
+        decode:
+            Whether to decode the data from bytes to string.
+            Default is True.
+
+        decode_method:
+            The method used to decode the message data.
+            Supported methods include standard encodings like "utf-8", "ascii", etc.
+            Default is "utf-8".
+
+        read_all_from_avro_kwargs:
+            Any additional keyword arguments to be passed to Beam's `ReadAllFromAvro` class.
+            Check official documentation:
+            https://beam.apache.org/releases/pydoc/2.64.0/apache_beam.io.avroio.html#apache_beam.io.avroio.ReadAllFromAvro
+
+        **kwargs:
+            Additional keyword arguments passed to base PTransform class.
+
+    Returns:
+        PCollection:
+            A PCollection of Avro records from the files within the specified datetime range.
+    """
+
+    DATETIME_REGEX = r"(\d{4}-\d{2}-\d{2}).*?(\d{2}_\d{2}_\d{2}Z)"
+    PATTERN_TEMPLATE = "{base_path}/{folder_path}/*.avro"
+
+    def __init__(
+        self,
+        base_path: str,
+        start_dt: str,
+        end_dt: str,
+        path_template: str = "{date}",
+        decode: bool = True,
+        decode_method: str = "utf-8",
+        read_all_from_avro_kwargs: Optional[dict[Any, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._base_path = base_path
+        self._start_dt = datetime_from_string(start_dt)
+        self._end_dt = datetime_from_string(end_dt)
+        self._path_template = path_template
+        self._decode = decode
+        self._decode_method = decode_method
+        self._read_all_from_avro_kwargs = read_all_from_avro_kwargs or {}
+
+        self._validate_decode_method()
+
+    def _generate_file_patterns(self) -> Sequence[str]:
+        current_date = self._start_dt.date()
+        end_date = self._end_dt.date()
+        patterns = []
+
+        while current_date <= end_date:
+            patterns.append(
+                self.PATTERN_TEMPLATE.format(
+                    base_path=self._base_path,
+                    folder_path=self._path_template.format(date=current_date.isoformat()),
+                )
+            )
+            current_date += timedelta(days=1)
+
+        return patterns
+
+    def _validate_decode_method(self) -> None:
+        try:
+            codecs.lookup(self._decode_method)
+        except LookupError as e:
+            raise ValueError(f"Unsupported decode method: {self._decode_method}") from e
+
+        logger.info(f"Using decode method: {self._decode_method}.")
+
+    def _decode_records(self, record: dict) -> dict:
+        record = {**record}
+        record["data"] = record["data"].decode(self._decode_method)
+
+        return record
+
+    def is_path_in_range(self, path: str) -> bool:
+        """Checks if a path containing a datetime is within the provided datetime range."""
+        dt = get_datetime_from_string(path)
+        if dt is None:
+            logger.error(
+                f"Couldn't extract datetime from path: {path} using regex: {self.DATETIME_REGEX}"
+            )
+
+            return False
+
+        res = self._start_dt <= dt < self._end_dt
+
+        logger.debug(f"Matched path (inside datetime range? = {res}).")
+        logger.debug(path)
+
+        return res
+
+    def expand(self, pcoll: PCollection) -> PCollection:
+        """Applies the transform to the pipeline root and returns a PCollection of messages.
+
+        Args:
+            pcoll:
+                An input PCollection. This is expected to be a `PBegin` when used with a real
+                or mocked `ReadFromPubSub`, since Pub/Sub sources begin from the pipeline root.
+
+        Returns:
+            beam.PCollection:
+                A PCollection of dictionaries where each dictionary contains:
+                - "data": the decoded message string (if decoding is enabled),
+                - "attributes": a dictionary of message attributes (if available).
+        """
+        logger.info("Generating file patterns...")
+        file_patterns = self._generate_file_patterns()
+
+        logger.info(f"Generated patterns: {file_patterns}")
+        records = (
+            pcoll
+            | "CreatePatterns" >> beam.Create(file_patterns)
+            | "MatchFiles" >> fileio.MatchAll()
+            | "FilterFilesByTime" >> beam.Filter(lambda m: self.is_path_in_range(m.path))
+            | "ReadAvroRecords" >> ReadAllFromAvro(**self._read_all_from_avro_kwargs)
+        )
+
+        if self._decode:
+            records = records | beam.Map(self._decode_records)
+
+        return records

--- a/src/gfw/common/datetime.py
+++ b/src/gfw/common/datetime.py
@@ -1,7 +1,12 @@
 """Utility functions for working with datetime objects and timezones."""
 
+import re
+
 from datetime import date, datetime, time, timezone, tzinfo
 from typing import Union
+
+
+ISOFORMAT_REGEX = r"(\d{4}-\d{2}-\d{2}).*?(\d{2}_\d{2}_\d{2}Z)"
 
 
 def datetime_from_timestamp(ts: Union[int, float], tz: tzinfo = timezone.utc) -> datetime:
@@ -63,3 +68,38 @@ def datetime_from_date(d: date, t: time = time(0, 0), tz: timezone = timezone.ut
         A timezone-aware datetime object.
     """
     return datetime.combine(d, t, tzinfo=tz)
+
+
+def get_datetime_from_string(
+    s: str, regex: str = ISOFORMAT_REGEX, tz: timezone = timezone.utc
+) -> Union[datetime, None]:
+    """Extracts datetime from a string using an ISO-FORMAT regular expression.
+
+    Args:
+        s:
+            Date part of the datetime.
+
+        regex:
+            The regular expression to use.
+            Defaults to regex that matches YYYY-MM-DD and HH_MM_SSZ.
+
+        tz:
+            The timezone to apply to the resulting datetime, if not present.
+            Defaults to UTC.
+
+    Returns:
+        A timezone-aware datetime object.
+    """
+    match = re.search(regex, s)
+
+    if not match:
+        return None
+
+    date_str = match.group(1)
+    time_str = match.group(2).replace("_", ":").replace("Z", "+00:00")
+    dt = datetime.fromisoformat(f"{date_str} {time_str}")
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=tz)
+
+    return dt

--- a/tests/beam/transforms/test_read_matching_avro_files.py
+++ b/tests/beam/transforms/test_read_matching_avro_files.py
@@ -1,0 +1,103 @@
+import logging
+
+import avro.schema
+import pytest
+
+from apache_beam.testing.test_pipeline import TestPipeline as _TestPipeline
+from apache_beam.testing.util import assert_that, equal_to
+from avro.datafile import DataFileWriter
+from avro.io import DatumWriter
+
+from gfw.common.beam.transforms import ReadMatchingAvroFiles
+
+
+# Define the Avro schema for our test data
+SCHEMA_STR = """
+{
+    "type": "record",
+    "name": "TestRecord",
+    "fields": [
+        {"name": "data", "type": "bytes"},
+        {"name": "timestamp", "type": "string"}
+    ]
+}
+"""
+SCHEMA = avro.schema.parse(SCHEMA_STR)
+
+
+def create_avro_file(filepath, records):
+    """Create a valid Avro container file with the given records."""
+    with open(filepath, "wb") as f:
+        writer = DataFileWriter(f, DatumWriter(), SCHEMA)
+        for record in records:
+            writer.append(record)
+        writer.close()
+
+
+@pytest.fixture
+def avro_files_base_path(tmp_path):
+    """Creates a temporary directory with a set of Avro files."""
+    base_path = tmp_path / "test_data"
+    base_path.mkdir()
+
+    # Define some records to write to the files
+    record_1_data = {"data": b"test_data_1", "timestamp": "2025-08-14T09:30:00Z"}
+    record_2_data = {"data": b"test_data_2", "timestamp": "2025-08-15T04:00:00Z"}
+    record_4_data = {"data": b"test_data_3", "timestamp": "2025-08-15T06:00:00Z"}  # Outside range
+    record_3_data = {"data": b"test_data_4", "timestamp": "2025-08-16T00:00:00Z"}  # Outside range
+
+    # Create directories for each date
+    dir_14 = base_path / "2025-08-14"
+    dir_15 = base_path / "2025-08-15"
+    dir_16 = base_path / "2025-08-16"
+
+    dir_14.mkdir()
+    dir_15.mkdir()
+    dir_16.mkdir()
+
+    # Create the Avro files inside the directories
+    create_avro_file(dir_14 / "file-2025-08-14_09_30_00Z.avro", [record_1_data])
+    create_avro_file(dir_15 / "file-2025-08-15_04_00_00Z.avro", [record_2_data])
+    create_avro_file(dir_15 / "file-2025-08-15_06_00_00Z.avro", [record_3_data])
+    create_avro_file(dir_16 / "file-2025-08-16_00_00_00Z.avro", [record_4_data])
+
+    return str(base_path)
+
+
+def test_read_matching_avro_files(avro_files_base_path):
+    """Tests the ReadMatchingAvroFiles PTransform with a local filesystem."""
+    start_dt = "2025-08-14T09:00:00"
+    end_dt = "2025-08-15T05:00:00"
+
+    # Define the expected output based on the created files and the date range
+    expected_output = [
+        {"data": "test_data_1", "timestamp": "2025-08-14T09:30:00Z"},
+        {"data": "test_data_2", "timestamp": "2025-08-15T04:00:00Z"},
+    ]
+
+    with _TestPipeline() as p:
+        output = p | "ReadMatchingAvroFiles" >> ReadMatchingAvroFiles(
+            base_path=avro_files_base_path, start_dt=start_dt, end_dt=end_dt
+        )
+
+        # Assert that the output PCollection matches our expected results
+        assert_that(output, equal_to(expected_output))
+
+
+def test_no_datetime_extraction_logs_error(caplog):
+    transform = ReadMatchingAvroFiles(
+        base_path="/tmp/some_path",  # doesn't matter for this
+        start_dt="2025-08-14T09:00:00",
+        end_dt="2025-08-15T00:00:00",
+    )
+
+    bad_path = "/path/without/datetime/structure/file.avro"
+
+    with caplog.at_level(logging.ERROR):
+        result = transform.is_path_in_range(bad_path)  # or whatever your method is called
+
+    # It should log the error
+    assert any("Couldn't extract datetime" in msg for msg in caplog.messages)
+
+    # And return False
+    assert result is False


### PR DESCRIPTION
### Summary

This PR adds a new `ReadMatchingAvroFiles` `PTransform`, enabling pipelines to read and process Avro files from GCS with datetime-based filtering.

Key changes:

- Implemented `ReadMatchingAvroFiles` PTransform:
  - Wraps Beam's `ReadFromAvro` to read multiple files from a base path.
  - Filters files by a provided datetime range using regex-based timestamp extraction from filenames.
- Added a helper `get_datetime_from_string` as part of the file filtering logic for extracting timestamps from strings.
- Added unit tests validating:
  - Correct file matching by datetime range.
  - Handling of files that do not contain valid timestamps.
  - Proper reading of local Avro files in test scenarios.

This PTransform allows pipelines like **pipe-nmea** to safely recover and process historical Avro data from GCS backups, ensuring no data loss during downtime or backfill operations.

https://globalfishingwatch.atlassian.net/browse/PIPELINE-2937