### PR TITLE
PIPELINE-2963: Add time buffering to ReadMatchingAvroFiles PTransform

### DIFF
--- a/tests/beam/transforms/test_read_matching_avro_files.py
+++ b/tests/beam/transforms/test_read_matching_avro_files.py
@@ -9,6 +9,7 @@ from avro.datafile import DataFileWriter
 from avro.io import DatumWriter
 
 from gfw.common.beam.transforms import ReadMatchingAvroFiles
+from gfw.common.datetime import datetime_from_isoformat
 
 
 # Define the Avro schema for our test data
@@ -23,6 +24,10 @@ SCHEMA_STR = """
 }
 """
 SCHEMA = avro.schema.parse(SCHEMA_STR)
+
+
+def record_time_fn(record: dict) -> bool:
+    return datetime_from_isoformat(record["timestamp"])
 
 
 def create_avro_file(filepath, records):
@@ -41,21 +46,28 @@ def avro_files_base_path(tmp_path):
     base_path.mkdir()
 
     # Define some records to write to the files
-    record_1_data = {"data": b"test_data_1", "timestamp": "2025-08-14T09:30:00Z"}
-    record_2_data = {"data": b"test_data_2", "timestamp": "2025-08-15T04:00:00Z"}
-    record_4_data = {"data": b"test_data_3", "timestamp": "2025-08-15T06:00:00Z"}  # Outside range
-    record_3_data = {"data": b"test_data_4", "timestamp": "2025-08-16T00:00:00Z"}  # Outside range
+    record_0_data = {"data": b"test_data_0", "timestamp": "2025-08-14T00:04:00+00:00"}
+    record_1_data = {"data": b"test_data_1", "timestamp": "2025-08-14T09:30:00+00:00"}
+    record_2_data = {"data": b"test_data_2", "timestamp": "2025-08-15T04:00:00+00:00"}
+
+    # Outside range
+    record_4_data = {"data": b"test_data_3", "timestamp": "2025-08-15T06:00:00+00:00"}
+    record_3_data = {"data": b"test_data_4", "timestamp": "2025-08-16T00:00:00+00:00"}
 
     # Create directories for each date
+    dir_13 = base_path / "2025-08-13"
     dir_14 = base_path / "2025-08-14"
     dir_15 = base_path / "2025-08-15"
     dir_16 = base_path / "2025-08-16"
 
+    dir_13.mkdir()
     dir_14.mkdir()
     dir_15.mkdir()
     dir_16.mkdir()
 
     # Create the Avro files inside the directories
+    # We put the first record inside range the day before, since this can happen in prod.
+    create_avro_file(dir_13 / "file-2025-08-13_23_59_00Z.avro", [record_0_data])
     create_avro_file(dir_14 / "file-2025-08-14_09_30_00Z.avro", [record_1_data])
     create_avro_file(dir_15 / "file-2025-08-15_04_00_00Z.avro", [record_2_data])
     create_avro_file(dir_15 / "file-2025-08-15_06_00_00Z.avro", [record_3_data])
@@ -66,13 +78,14 @@ def avro_files_base_path(tmp_path):
 
 def test_read_matching_avro_files(avro_files_base_path):
     """Tests the ReadMatchingAvroFiles PTransform with a local filesystem."""
-    start_dt = "2025-08-14T09:00:00"
+    start_dt = "2025-08-14T00:00:00"
     end_dt = "2025-08-15T05:00:00"
 
     # Define the expected output based on the created files and the date range
     expected_output = [
-        {"data": "test_data_1", "timestamp": "2025-08-14T09:30:00Z"},
-        {"data": "test_data_2", "timestamp": "2025-08-15T04:00:00Z"},
+        {"data": "test_data_0", "timestamp": "2025-08-14T00:04:00+00:00"},
+        {"data": "test_data_1", "timestamp": "2025-08-14T09:30:00+00:00"},
+        {"data": "test_data_2", "timestamp": "2025-08-15T04:00:00+00:00"},
     ]
 
     path_template = Template("${base_path}/{date}/*.avro")
@@ -83,6 +96,7 @@ def test_read_matching_avro_files(avro_files_base_path):
             path=path,
             start_dt=start_dt,
             end_dt=end_dt,
+            record_time_fn=record_time_fn,
             date_format="%Y-%m-%d",
             time_format="%H_%M_%SZ",
         )


### PR DESCRIPTION
## Overview

This PR fixes an issue where the first records of a day could be missing in the output of  ReadMatchingAvroFiles because they were written in the last file of the previous day. 

## Changes

- Adds `record_time_fn` to filter records based on their actual timestamp.
- Introduces `buffer_days` and `buffer_minutes` to safely include boundary files without fetching excessive data.
- Optional `strict` mode to control whether records with invalid timestamps raise errors or are skipped.

## Impact

- Ensures that early records of the day are included in backfills.
- Improves reliability of time-partitioned Avro reads for historical data pipelines.
