### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     env:
       VENV: .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # Project metadata.
 [project]
 name = "gfw-common"
-version = "0.2.0"
+version = "0.3.0"
 description = "Common place for GFW reusable Python components."
 readme = "README.md"
 license = "Apache-2.0"
@@ -65,7 +65,6 @@ bq = [
 # Apache Beam
 beam = [
   "apache-beam[gcp]~=2.0",
-  "google-cloud-profiler~=4.1",
 ]
 
 # Linting and code quality tools

--- a/tests/beam/pipeline/test_base.py
+++ b/tests/beam/pipeline/test_base.py
@@ -110,33 +110,3 @@ def test_pipeline_options():
 
     # Check if 'setup_file' is included when 'DATAFLOW_SDK_CONTAINER_IMAGE' is not set.
     assert "setup_file" in pipeline_options.view_as(PipelineOptions).get_all_options()
-
-
-def test_profiler_enabled_runs_profiler(monkeypatch):
-    called = {}
-
-    def mock_start(service, service_version, verbose):
-        called["called"] = True
-        called["service"] = service
-        called["version"] = service_version
-        called["verbose"] = verbose
-
-    monkeypatch.setattr("gfw.common.beam.pipeline.base.googlecloudprofiler.start", mock_start)
-
-    dag = LinearDag(sources=[DummySource()])
-
-    pipeline = Pipeline(
-        name="test-profiler-pipeline",
-        version="1.2.3",
-        dag=dag,
-        runner="DirectRunner",
-        dataflow_service_options=["enable_google_cloud_profiler"],
-        project="test-project",
-    )
-
-    pipeline.run()
-
-    assert called["called"] is True
-    assert called["service"] == "test-profiler-pipeline"
-    assert called["version"] == "1.2.3"
-    assert called["verbose"] == 2


### PR DESCRIPTION
In order to support Python 3.13, we remove the` google-cloud-profiler`. This library officially supports only up to Python 3.11. In Python 3.13 fails to installs. It is not proven to be really useful so we can remove it for the moment. 