### PR TITLE
Add publish_time in ReadAndDecodeFromPubSub output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # Project metadata.
 [project]
 name = "gfw-common"
-version = "0.6.1"
+version = "0.7.0"
 description = "Common place for GFW reusable Python components."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/gfw/common/beam/transforms/pubsub.py
+++ b/src/gfw/common/beam/transforms/pubsub.py
@@ -147,7 +147,12 @@ class ReadAndDecodeFromPubSub(beam.PTransform[Any, Any]):
         if self._decode:
             data = message.data.decode(self._decode_method)
 
-        return {"data": data, "attributes": message.attributes}
+        return {
+            "data": data,
+            "attributes": message.attributes,
+            "publish_time": message.publish_time,
+            "message_id": message.message_id,
+        }
 
     def _validate_decode_method(self) -> None:
         try:

--- a/tests/beam/transforms/test_pubsub.py
+++ b/tests/beam/transforms/test_pubsub.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 from apache_beam.io.gcp.pubsub import ReadFromPubSub
@@ -40,6 +42,8 @@ def test_read_and_decode_from_pubsub():
                 "key2": "value2",
                 "key1": "value1",
             },
+            "publish_time": datetime(2026, 1, 1),
+            "message_id": "123",
         }
     ]
 
@@ -60,6 +64,8 @@ def test_read_and_decode_from_pubsub():
                     "key1": "value1",
                     "key2": "value2",
                 },
+                "publish_time": datetime(2026, 1, 1),
+                "message_id": "123",
             }
         ]
 
@@ -72,6 +78,8 @@ def test_read_without_decoding():
         {
             "data": b"some-bytes",
             "attributes": {"source": "test"},
+            "publish_time": datetime(2026, 1, 1),
+            "message_id": "123",
         }
     ]
 


### PR DESCRIPTION
We want to not discard `publish_time` so we can grab it downstream from the message itself, instead of the timestamp param of a DoFn. 