### PR TITLE
Fix CLI namespace excluding None defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # Project metadata.
 [project]
 name = "gfw-common"
-version = "0.11.0"
+version = "0.11.1"
 description = "Common place for GFW reusable Python components."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/gfw/common/cli/cli.py
+++ b/src/gfw/common/cli/cli.py
@@ -248,8 +248,8 @@ class CLI:
 
         # Resolve configuration based on cli_args, config file and defaults.
         # cli_args takes precedence over config file and config file over defaults.
-        common_defaults = filter_none_values(self._main_command.defaults())
-        defaults_args = filter_none_values(command.defaults())
+        common_defaults = self._main_command.defaults()
+        defaults_args = command.defaults()
         cli_args = filter_none_values(cli_args)
 
         defaults_args.update(common_defaults)
@@ -362,7 +362,7 @@ class CLI:
     def _validate_required_args(self, command: Command, config: dict[str, Any]) -> None:
         missing = []
         for o in command.options:
-            if o.required and o.dest not in config:
+            if o.required and config.get(o.dest) is None:
                 missing.append(o.dest)
 
         if missing:
@@ -392,6 +392,9 @@ class CLI:
         argument = "--{name}{sep}{value}"
 
         for k, v in config.items():
+            if v is None:
+                continue
+
             name = self._resolve_cli_name(k)
             value = v
             sep = "="

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -262,14 +262,14 @@ def test_only_render(main_command, subcommand, use_underscore, sep):
         "program \\"
         "\nsubcommand \\"
         "\n--other 4 \\"
+        "\n--number{sep}2=2 \\"
         "\n--number{sep}3=3 \\"
         "\n--date{sep}2=2025-01-02 \\"
         "\n--list{sep}2=ABC,EFG \\"
         "\n--boolean{sep}2 \\"
         "\n--number{sep}1=1 \\"
         "\n--date{sep}1=2025-01-01 \\"
-        "\n--project=my-project \\"
-        "\n--number{sep}2=2"
+        "\n--project=my-project"
     ).format(sep=sep)
 
     assert res == expected


### PR DESCRIPTION
Related to https://globalfishingwatch.atlassian.net/browse/PIPELINE-4036

---


## Fix CLI namespace excluding options with `None` defaults

  ### Problem

  `filter_none_values` was applied to the defaults dict before building the `DeepChainMap`, causing options with `default=None` to be silently dropped from the resolved config. The   `SimpleNamespace` passed to `run` was therefore missing attributes for those options.

  ### Changes

  - **Stop filtering `None` from defaults** — filtering is now only applied to `cli_args`, where argparse uses `None` as a sentinel for unspecified args. Defaults are kept as-is.
  - **`_validate_required_args`** — check changed from `o.dest not in config` to `config.get(o.dest) is None`, since required options now always appear in config.
  - **`_render_command_line_call`** — skip `None` values when rendering, since `None` can't be expressed as a CLI argument.

  ### Result

  The `SimpleNamespace` passed to `run` always contains every declared option. Options not provided by the user are present with value `None`. If callers unpack via `**vars(config)`, filtering `None` is their responsibility.