### PR TITLE
Add WritePartitionedParquet transform with HivePartitionConfig

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # Project metadata.
 [project]
 name = "gfw-common"
-version = "0.11.4"
+version = "0.12.0"
 description = "Common place for GFW reusable Python components."
 readme = "README.md"
 license = "Apache-2.0"
@@ -60,6 +60,7 @@ bq = [
 # Apache Beam
 beam = [
   "apache-beam[gcp]~=2.0",
+  "pyarrow~=18.1",
 ]
 
 # Linting and code quality tools

--- a/src/gfw/common/beam/transforms/__init__.py
+++ b/src/gfw/common/beam/transforms/__init__.py
@@ -22,6 +22,7 @@ Classes
 
    ApplySlidingWindows
    GroupBy
+   HivePartitionConfig
    ReadAndDecodeFromPubSub
    ReadFromBigQuery
    ReadFromJson
@@ -29,6 +30,7 @@ Classes
    SampleAndLogElements
    WriteToBigQueryWrapper
    WriteToJson
+   WritePartitionedParquet
 
 Extra classes useful for testing
 --------------------------------
@@ -45,6 +47,7 @@ Extra classes useful for testing
 from .apply_sliding_windows import ApplySlidingWindows
 from .bigquery import FakeWriteToBigQuery, WriteToBigQueryWrapper
 from .group_by import GroupBy
+from .parquet import HivePartitionConfig, WritePartitionedParquet
 from .pubsub import FakeReadFromPubSub, ReadAndDecodeFromPubSub
 from .read_from_bigquery import ReadFromBigQuery
 from .read_from_json import ReadFromJson
@@ -58,11 +61,13 @@ __all__ = [
     "FakeReadFromPubSub",
     "FakeWriteToBigQuery",
     "GroupBy",
+    "HivePartitionConfig",
     "ReadAndDecodeFromPubSub",
     "ReadFromBigQuery",
     "ReadFromJson",
     "ReadMatchingAvroFiles",
     "SampleAndLogElements",
+    "WritePartitionedParquet",
     "WriteToBigQueryWrapper",
     "WriteToJson",
 ]

--- a/src/gfw/common/beam/transforms/parquet.py
+++ b/src/gfw/common/beam/transforms/parquet.py
@@ -1,0 +1,283 @@
+"""PTransform for writing hive-partitioned Parquet files."""
+
+from dataclasses import dataclass, field
+from typing import Any, BinaryIO, Callable, Iterable, Literal
+
+import apache_beam as beam
+import pyarrow as pa
+
+from apache_beam.io import fileio
+from apache_beam.io.fileio import FileSink
+from apache_beam.transforms.trigger import AccumulationMode
+from apache_beam.transforms.window import IntervalWindow
+
+
+Row = dict[str, Any]
+Partitions = dict[str, Callable[[str], str]]
+
+
+@dataclass
+class HivePartitionConfig:
+    """Hive-style partition layout for :class:`WritePartitionedParquet`.
+
+    Args:
+        fields:
+            Extra partition dimensions applied before the time component, as
+            an ordered ``{field_name: fn}`` dict. ``field_name`` is read from
+            the element and ``fn`` maps its value to a partition string.
+            Insertion order determines the directory hierarchy.
+            Defaults to no extra dimensions (time-only partitioning).
+
+        prefix:
+            Prefix applied to every partition key name, including the time
+            components. Avoids collisions with element field names when
+            BigQuery reads the external table. Defaults to ``"event_"``.
+
+        time_granularity:
+            Granularity of the time partition component. ``"hour"`` produces
+            ``{prefix}date=YYYY-MM-DD/{prefix}hour=HH/``; ``"day"`` produces
+            ``{prefix}date=YYYY-MM-DD/`` only. Should be chosen based on query
+            patterns, independently of ``window_size``. Defaults to ``"hour"``.
+    """
+
+    fields: Partitions = field(default_factory=dict)
+    prefix: str = "event_"
+    time_granularity: Literal["hour", "day"] = "hour"
+
+
+def _partition_path(element: tuple[str, Row]) -> str:
+    partition, _ = element
+    return partition
+
+
+class WritePartitionedParquet(beam.PTransform):
+    """Writes elements to hive-partitioned Parquet files.
+
+    Output files are organized using Hive-style partitioning. Time partitioning
+    is always present and derived from the window start. Extra dimensions are
+    user-defined and prepended before the time component::
+
+        {path}/{prefix}{dim1}={v1}/{prefix}{dim2}={v2}/.../{prefix}date=YYYY-MM-DD/{prefix}hour=HH/
+
+    For example, with ``HivePartitionConfig(fields={"source": fn})``::
+
+        {path}/event_source=kpler/event_date=2024-01-15/event_hour=08/
+
+    ## Tuning window_size and num_shards
+
+    The primary tuning knob is the combination of ``window_size`` and
+    ``num_shards``, which together determine output file size::
+
+        rows_per_file = (rows_per_second x window_size) / num_shards
+
+    File size directly controls:
+
+    - Memory consumption per worker: larger files = more memory during flush.
+    - Query performance: files that are too small increase metadata overhead
+      in BigQuery external table scans; files that are too large reduce
+      parallelism.
+    - GCS write latency: files must be written within the window duration,
+      so very large files with short windows can cause the pipeline to stall.
+
+    As a rule of thumb, target file sizes of 10-50 MB.
+
+    ## Row groups
+
+    Each output file contains a single Parquet row group, which is optimal
+    for BigQuery external table scans. This is a natural consequence of
+    writing all rows for a shard in a single flush at window close.
+
+    Args:
+        path:
+            Output path where files will be written.
+
+        schema:
+            PyArrow schema used by the Parquet writer.
+
+        window_size:
+            Size of the fixed window in seconds. Controls how frequently
+            files are written. Shorter windows reduce latency and file size
+            but produce more files. Defaults to 60 seconds.
+
+        allowed_lateness:
+            Allowed lateness in seconds. Late records arriving within this
+            duration after the window closes will still be included.
+            Defaults to 0.
+
+        accumulation_mode:
+            Beam accumulation mode. Defaults to ``DISCARDING``, which is
+            correct for most streaming use cases.
+
+        num_shards:
+            Number of output files per partition per window. Must be tuned
+            together with ``window_size`` to hit the target file size.
+            Defaults to 6.
+
+        codec:
+            Compression codec for Parquet. Defaults to ``"snappy"``.
+
+        file_suffix:
+            File suffix. Defaults to ``".parquet"``.
+
+        partition:
+            Hive partition layout. Defaults to hourly time-only partitioning
+            with ``"event_"`` prefix. See :class:`HivePartitionConfig`.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        schema: pa.Schema,
+        window_size: int = 60,
+        allowed_lateness: int = 0,
+        accumulation_mode: AccumulationMode = AccumulationMode.DISCARDING,  # type: ignore
+        num_shards: int = 6,
+        codec: str = "snappy",
+        file_suffix: str = ".parquet",
+        partition: HivePartitionConfig | None = None,
+    ) -> None:
+        self._path = path
+        self._schema = schema
+        self._window_size = window_size
+        self._allowed_lateness = allowed_lateness
+        self._accumulation_mode = accumulation_mode
+        self._num_shards = num_shards
+        self._codec = codec
+        self._file_suffix = file_suffix
+        self._partition = partition or HivePartitionConfig()
+        self._validate()
+
+    def _validate(self) -> None:
+        max_window = {"hour": 3600, "day": 86400}[self._partition.time_granularity]
+        if self._window_size > max_window:
+            granularity = self._partition.time_granularity
+            raise ValueError(
+                f"window_size={self._window_size}s exceeds the {granularity} partition period "
+                f"({max_window}s). Data spanning multiple {granularity}s would be "
+                f"silently filed under the window-start {granularity} only."
+            )
+
+    def expand(self, pcoll: beam.PCollection) -> beam.PCollection:  # type: ignore[name-defined]
+        """Applies windowing, partition keying, and Parquet file writing."""
+        return (
+            pcoll
+            | "Window"
+            >> beam.WindowInto(
+                beam.window.FixedWindows(self._window_size),  # type: ignore[attr-defined]
+                allowed_lateness=beam.utils.timestamp.Duration(seconds=self._allowed_lateness),
+                accumulation_mode=self._accumulation_mode,
+            )
+            | "AddPartitionKey" >> beam.ParDo(_AddPartitionKey(self._partition))
+            | "WriteParquet"
+            >> fileio.WriteToFiles(
+                path=self._path,
+                destination=_partition_path,
+                sink=lambda dest: _ParquetSink(schema=self._schema, codec=self._codec),
+                file_naming=_safe_filenaming(suffix=self._file_suffix),
+                shards=self._num_shards,
+                # The following ensures we always use sharded destinations.
+                # All the data in the window will be split in a fixed X number of shards.
+                max_writers_per_bundle=0,
+            )
+        )
+
+
+class _AddPartitionKey(beam.DoFn):
+    """Builds the full hive partition path for each element.
+
+    Derives the time component from the window start (cached per window) and
+    prepends any user-defined extra partition dimensions.
+    """
+
+    def __init__(self, partition: HivePartitionConfig) -> None:
+        self._partition = partition
+
+    def start_bundle(self) -> None:
+        """Initialises the per-bundle window time cache."""
+        self._time_cache: dict[Any, str] = {}
+
+    def process(
+        self,
+        element: Row,
+        window: IntervalWindow = beam.DoFn.WindowParam,  # type: ignore[assignment]
+    ) -> Iterable[tuple[str, Row]]:
+        """Builds the partition path and yields a keyed element.
+
+        Args:
+            element:
+                The PCollection element (a dict row).
+
+            window:
+                Window metadata containing start/end timestamps.
+
+        Yields:
+            A tuple of the full partition path string and the element.
+        """
+        if window.start not in self._time_cache:
+            start = window.start.to_utc_datetime()
+            time_parts = [f"{self._partition.prefix}date={start:%Y-%m-%d}"]
+
+            if self._partition.time_granularity == "hour":
+                time_parts.append(f"{self._partition.prefix}hour={start:%H}")
+
+            self._time_cache[window.start] = "/".join(time_parts) + "/"
+
+        extra = "/".join(
+            f"{self._partition.prefix}{field}={fn(element[field])}"
+            for field, fn in self._partition.fields.items()
+        )
+
+        path = (extra + "/" if extra else "") + self._time_cache[window.start]
+
+        yield path, element
+
+
+class _ParquetSink(FileSink):
+    """A :class:`~apache_beam.io.fileio.FileSink` that buffers rows and flushes as one row group.
+
+    Args:
+        schema: PyArrow schema for the Parquet file.
+        codec: Parquet compression codec (e.g. ``"snappy"``, ``"zstd"``).
+    """
+
+    def __init__(self, schema: pa.Schema, codec: str = "snappy") -> None:
+        self._schema = schema
+        self._codec = codec
+
+    def open(self, fh: BinaryIO) -> None:
+        self._writer = pa.parquet.ParquetWriter(
+            fh,
+            self._schema,
+            compression=self._codec,
+        )
+        self._buffer: list[Row] = []
+
+    def write(self, element: tuple[str, Row]) -> None:
+        _, row = element
+        self._buffer.append(row)
+
+    def flush(self) -> None:
+        try:
+            if self._buffer:
+                batch = pa.RecordBatch.from_pylist(self._buffer, schema=self._schema)
+                self._writer.write_batch(batch)
+        finally:
+            self._buffer = None  # type: ignore[assignment]
+            self._writer.close()
+            self._writer = None
+
+
+def _safe_filenaming(suffix: Any = None) -> Callable[..., str]:
+    def _inner(
+        window: Any,
+        pane: Any,
+        shard_index: Any,
+        total_shards: Any,
+        compression: Any,
+        destination: Any,
+    ) -> str:
+        return fileio.destination_prefix_naming(suffix)(  # type: ignore[call-arg]
+            window, pane, shard_index, total_shards, compression, destination
+        ).replace(":", ".")
+
+    return _inner

--- a/tests/beam/transforms/test_parquet.py
+++ b/tests/beam/transforms/test_parquet.py
@@ -1,0 +1,515 @@
+"""Unit tests for transforms/write_to_parquet.py."""
+
+import io
+import tempfile
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import apache_beam as beam
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that, equal_to
+from apache_beam.transforms.trigger import AccumulationMode
+from apache_beam.transforms.window import IntervalWindow
+from apache_beam.utils.timestamp import Timestamp
+
+from gfw.common.beam.transforms.parquet import (
+    HivePartitionConfig,
+    WritePartitionedParquet,
+    _AddPartitionKey,
+    _ParquetSink,
+    _safe_filenaming,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SCHEMA = pa.schema(
+    [
+        pa.field("mmsi", pa.int64(), nullable=True),
+        pa.field("nmea", pa.string(), nullable=False),
+        pa.field("x", pa.float64(), nullable=True),
+    ]
+)
+
+
+def make_window(year=2024, month=1, day=15, hour=8, minute=0, second=0):
+    dt = datetime(year, month, day, hour, minute, second, tzinfo=timezone.utc)
+    start = Timestamp(dt.timestamp())
+    return IntervalWindow(start, Timestamp(dt.timestamp() + 60))
+
+
+def make_fh():
+    return io.BytesIO()
+
+
+def read_parquet(fh: io.BytesIO) -> pa.Table:
+    fh.seek(0)
+    return pq.read_table(fh)
+
+
+def make_keyed(row: dict, path: str = "event_date=2024-01-15/event_hour=08/") -> tuple:
+    return (path, row)
+
+
+def call_naming(suffix, hour=8):
+    fn = _safe_filenaming(suffix=suffix)
+    pane = MagicMock()
+    pane.index = 0
+    pane.is_last = True
+    dest = f"event_source=kpler/event_date=2024-01-15/event_hour=0{hour}/"
+    return fn(make_window(hour=hour), pane, 0, 1, None, dest)
+
+
+def run_partition(dofn, element, window):
+    return list(dofn.process(element, window=window))
+
+
+def make_dofn(partition: HivePartitionConfig | None = None):
+    dofn = _AddPartitionKey(partition or HivePartitionConfig())
+    dofn.start_bundle()
+    return dofn
+
+
+# ---------------------------------------------------------------------------
+# _AddPartitionKey — time-only (no extra partitions)
+# ---------------------------------------------------------------------------
+
+
+def test_time_only_hourly():
+    dofn = make_dofn()
+    path, _ = run_partition(dofn, {}, make_window(2024, 1, 15, 8))[0]
+    assert path == "event_date=2024-01-15/event_hour=08/"
+
+
+def test_time_only_daily():
+    dofn = make_dofn(HivePartitionConfig(time_granularity="day"))
+    path, _ = run_partition(dofn, {}, make_window(2024, 1, 15, 8))[0]
+    assert path == "event_date=2024-01-15/"
+
+
+def test_time_only_midnight():
+    dofn = make_dofn()
+    path, _ = run_partition(dofn, {}, make_window(2024, 3, 1, 0))[0]
+    assert path == "event_date=2024-03-01/event_hour=00/"
+
+
+def test_time_only_end_of_day():
+    dofn = make_dofn()
+    path, _ = run_partition(dofn, {}, make_window(2024, 3, 1, 23))[0]
+    assert path == "event_date=2024-03-01/event_hour=23/"
+
+
+# ---------------------------------------------------------------------------
+# _AddPartitionKey — extra partitions
+# ---------------------------------------------------------------------------
+
+
+def test_single_partition_prepended():
+    dofn = make_dofn(HivePartitionConfig(fields={"source": lambda v: v}))
+    path, _ = run_partition(dofn, {"source": "kpler"}, make_window(2024, 1, 15, 8))[0]
+    assert path == "event_source=kpler/event_date=2024-01-15/event_hour=08/"
+
+
+def test_multiple_partitions_ordered():
+    dofn = make_dofn(
+        HivePartitionConfig(
+            fields={
+                "source": lambda v: v,
+                "receiver_type": lambda v: v,
+            }
+        )
+    )
+    path, _ = run_partition(
+        dofn, {"source": "kpler", "receiver_type": "satellite"}, make_window(2024, 1, 15, 8)
+    )[0]
+    expected = (
+        "event_source=kpler/event_receiver_type=satellite/event_date=2024-01-15/event_hour=08/"
+    )
+    assert path == expected
+
+
+def test_partition_fn_applied():
+    dofn = make_dofn(HivePartitionConfig(fields={"source": lambda v: v.split("-")[0]}))
+    path, _ = run_partition(dofn, {"source": "kpler-terrestrial"}, make_window(2024, 1, 15, 8))[0]
+    assert path == "event_source=kpler/event_date=2024-01-15/event_hour=08/"
+
+
+def test_custom_partition_prefix():
+    dofn = make_dofn(HivePartitionConfig(fields={"source": lambda v: v}, prefix="p_"))
+    path, _ = run_partition(dofn, {"source": "kpler"}, make_window(2024, 1, 15, 8))[0]
+    assert path == "p_source=kpler/p_date=2024-01-15/p_hour=08/"
+
+
+def test_element_passed_through_unchanged():
+    dofn = make_dofn(HivePartitionConfig(fields={"source": lambda v: v}))
+    row = {"source": "kpler", "mmsi": 123}
+    _, value = run_partition(dofn, row, make_window())[0]
+    assert value is row
+
+
+# ---------------------------------------------------------------------------
+# _AddPartitionKey — caching
+# ---------------------------------------------------------------------------
+
+
+def test_time_cache_hit_same_window():
+    dofn = make_dofn()
+    w = make_window(hour=8)
+    run_partition(dofn, {}, w)
+    run_partition(dofn, {}, w)
+    assert len(dofn._time_cache) == 1
+
+
+def test_time_cache_miss_different_window():
+    dofn = make_dofn()
+    run_partition(dofn, {}, make_window(hour=8))
+    run_partition(dofn, {}, make_window(hour=9))
+    assert len(dofn._time_cache) == 2
+
+
+def test_time_cache_called_once_per_window_regardless_of_partition_values():
+    """to_utc_datetime is called once per window even with many distinct sources."""
+    dofn = make_dofn(HivePartitionConfig(fields={"source": lambda v: v}))
+    w = make_window(hour=8)
+    for source in ["kpler", "spire", "orbcomm", "exactearth"]:
+        run_partition(dofn, {"source": source}, w)
+    assert len(dofn._time_cache) == 1
+
+
+def test_start_bundle_resets_time_cache():
+    dofn = make_dofn()
+    run_partition(dofn, {}, make_window(hour=8))
+    dofn.start_bundle()
+    assert dofn._time_cache == {}
+
+
+# ---------------------------------------------------------------------------
+# _AddPartitionKey — pipeline integration
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_integration_with_source():
+    with TestPipeline() as p:
+        window = make_window(2024, 1, 15, 10)
+        rows = [{"mmsi": i, "source": "kpler"} for i in range(3)]
+        result = (
+            p
+            | beam.Create(rows)
+            | beam.Map(lambda r: beam.window.TimestampedValue(r, window.start))
+            | beam.WindowInto(beam.window.FixedWindows(60))
+            | beam.ParDo(_AddPartitionKey(HivePartitionConfig(fields={"source": lambda v: v})))
+            | beam.Map(lambda x: x[0])
+        )
+        assert_that(
+            result, equal_to(["event_source=kpler/event_date=2024-01-15/event_hour=10/"] * 3)
+        )
+
+
+def test_pipeline_integration_time_only():
+    with TestPipeline() as p:
+        window = make_window(2024, 1, 15, 10)
+        rows = [{"mmsi": i} for i in range(3)]
+        result = (
+            p
+            | beam.Create(rows)
+            | beam.Map(lambda r: beam.window.TimestampedValue(r, window.start))
+            | beam.WindowInto(beam.window.FixedWindows(60))
+            | beam.ParDo(_AddPartitionKey(HivePartitionConfig()))
+            | beam.Map(lambda x: x[0])
+        )
+        assert_that(result, equal_to(["event_date=2024-01-15/event_hour=10/"] * 3))
+
+
+# ---------------------------------------------------------------------------
+# _safe_filenaming
+# ---------------------------------------------------------------------------
+
+
+def test_safe_filenaming_no_colons():
+    assert ":" not in call_naming(".parquet")
+
+
+def test_safe_filenaming_suffix_appended():
+    assert call_naming(".parquet").endswith(".parquet")
+
+
+def test_safe_filenaming_no_suffix_no_colons():
+    assert ":" not in call_naming(None)
+
+
+# ---------------------------------------------------------------------------
+# _ParquetSink — construction
+# ---------------------------------------------------------------------------
+
+
+def test_sink_stores_schema_and_codec():
+    s = _ParquetSink(schema=SCHEMA, codec="zstd")
+    assert s._schema == SCHEMA
+    assert s._codec == "zstd"
+
+
+def test_sink_default_codec():
+    assert _ParquetSink(schema=SCHEMA)._codec == "snappy"
+
+
+# ---------------------------------------------------------------------------
+# _ParquetSink — open
+# ---------------------------------------------------------------------------
+
+
+def test_open_creates_writer_and_empty_buffer():
+    s = _ParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    assert isinstance(s._writer, pa.parquet.ParquetWriter)
+    assert s._buffer == []
+    s.flush()
+
+
+def test_open_passes_codec_to_writer():
+    s = _ParquetSink(schema=SCHEMA, codec="gzip")
+    fh = make_fh()
+    with patch("pyarrow.parquet.ParquetWriter") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        s.open(fh)
+    mock_cls.assert_called_once_with(fh, SCHEMA, compression="gzip")
+
+
+# ---------------------------------------------------------------------------
+# _ParquetSink — write
+# ---------------------------------------------------------------------------
+
+
+def test_write_appends_row():
+    s = _ParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    row = {"mmsi": 1, "nmea": "x", "x": 1.0}
+    s.write(make_keyed(row))
+    assert s._buffer == [row]
+    s.flush()
+
+
+def test_write_ignores_partition_key():
+    s = _ParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    row = {"mmsi": 1, "nmea": "x", "x": None}
+    s.write(("some/partition/path/", row))
+    assert s._buffer[0] is row
+    s.flush()
+
+
+def test_write_accumulates_multiple_rows():
+    s = _ParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    rows = [{"mmsi": i, "nmea": f"m{i}", "x": float(i)} for i in range(5)]
+    for row in rows:
+        s.write(make_keyed(row))
+    assert len(s._buffer) == 5
+    s.flush()
+
+
+# ---------------------------------------------------------------------------
+# _ParquetSink — flush: normal path
+# ---------------------------------------------------------------------------
+
+
+def test_flush_writes_correct_data():
+    s = _ParquetSink(schema=SCHEMA)
+    fh = make_fh()
+    s.open(fh)
+    for row in [{"mmsi": 1, "nmea": "msg1", "x": 1.0}, {"mmsi": 2, "nmea": "msg2", "x": 2.0}]:
+        s.write(make_keyed(row))
+    s.flush()
+    table = read_parquet(fh)
+    assert table.num_rows == 2
+    assert table.column("nmea").to_pylist() == ["msg1", "msg2"]
+
+
+def test_flush_empty_buffer_does_not_raise():
+    s = _ParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    s.flush()
+    assert s._writer is None
+    assert s._buffer is None
+
+
+def test_flush_nulls_writer_and_buffer():
+    s = _ParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    s.write(make_keyed({"mmsi": 1, "nmea": "x", "x": None}))
+    s.flush()
+    assert s._writer is None
+    assert s._buffer is None
+
+
+def test_flush_handles_null_values():
+    s = _ParquetSink(schema=SCHEMA)
+    fh = make_fh()
+    s.open(fh)
+    s.write(make_keyed({"mmsi": None, "nmea": "msg", "x": None}))
+    s.flush()
+    table = read_parquet(fh)
+    assert table.column("mmsi").to_pylist() == [None]
+    assert table.column("x").to_pylist() == [None]
+
+
+def test_flush_produces_single_row_group():
+    s = _ParquetSink(schema=SCHEMA)
+    fh = make_fh()
+    s.open(fh)
+    for i in range(100):
+        s.write(make_keyed({"mmsi": i, "nmea": f"m{i}", "x": float(i)}))
+    s.flush()
+    fh.seek(0)
+    assert pq.ParquetFile(fh).metadata.num_row_groups == 1
+
+
+# ---------------------------------------------------------------------------
+# _ParquetSink — flush: exception safety
+# ---------------------------------------------------------------------------
+
+
+def test_flush_closes_writer_if_write_batch_raises():
+    s = _ParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    s.write(make_keyed({"mmsi": 1, "nmea": "x", "x": 1.0}))
+    mock_writer = MagicMock()
+    mock_writer.write_batch.side_effect = RuntimeError("disk full")
+    s._writer = mock_writer
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        s.flush()
+
+    mock_writer.close.assert_called_once()
+    assert s._writer is None
+    assert s._buffer is None
+
+
+def test_flush_closes_writer_if_from_pylist_raises():
+    bad_schema = pa.schema([pa.field("mmsi", pa.int64())])
+    s = _ParquetSink(schema=bad_schema, codec="snappy")
+    s.open(make_fh())
+    s._buffer = [{"mmsi": "not-an-int"}]
+    mock_writer = MagicMock()
+    s._writer = mock_writer
+
+    with pytest.raises(pa.lib.ArrowInvalid):
+        s.flush()
+
+    mock_writer.close.assert_called_once()
+    assert s._writer is None
+    assert s._buffer is None
+
+
+# ---------------------------------------------------------------------------
+# WritePartitionedParquet — constructor
+# ---------------------------------------------------------------------------
+
+
+def test_write_partitioned_defaults():
+    t = WritePartitionedParquet(path="gs://bucket/path", schema=SCHEMA)
+    assert t._path == "gs://bucket/path"
+    assert t._schema is SCHEMA
+    assert t._window_size == 60
+    assert t._allowed_lateness == 0
+    assert t._num_shards == 6
+    assert t._codec == "snappy"
+    assert t._file_suffix == ".parquet"
+    assert t._partition == HivePartitionConfig()
+
+
+def test_write_partitioned_custom_parameters():
+    cfg = HivePartitionConfig(fields={"source": lambda v: v}, prefix="p_", time_granularity="day")
+    t = WritePartitionedParquet(
+        path="gs://other/path",
+        schema=SCHEMA,
+        window_size=30,
+        allowed_lateness=10,
+        accumulation_mode=AccumulationMode.ACCUMULATING,
+        num_shards=5,
+        codec="zstd",
+        file_suffix=".snappy.parquet",
+        partition=cfg,
+    )
+    assert t._window_size == 30
+    assert t._allowed_lateness == 10
+    assert t._num_shards == 5
+    assert t._codec == "zstd"
+    assert t._file_suffix == ".snappy.parquet"
+    assert t._partition.prefix == "p_"
+    assert t._partition.time_granularity == "day"
+
+
+def test_window_size_exceeds_hour_granularity_raises():
+    with pytest.raises(ValueError, match="window_size"):
+        WritePartitionedParquet(path="gs://b/p", schema=SCHEMA, window_size=3601)
+
+
+def test_window_size_exceeds_day_granularity_raises():
+    with pytest.raises(ValueError, match="window_size"):
+        WritePartitionedParquet(
+            path="gs://b/p",
+            schema=SCHEMA,
+            window_size=86401,
+            partition=HivePartitionConfig(time_granularity="day"),
+        )
+
+
+def test_window_size_equal_to_granularity_is_valid():
+    WritePartitionedParquet(path="gs://b/p", schema=SCHEMA, window_size=3600)
+    WritePartitionedParquet(
+        path="gs://b/p",
+        schema=SCHEMA,
+        window_size=86400,
+        partition=HivePartitionConfig(time_granularity="day"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# WritePartitionedParquet — expand integration
+# ---------------------------------------------------------------------------
+
+
+def test_expand_with_source_partition():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with TestPipeline() as p:
+            window = make_window(2024, 1, 15, 10)
+            rows = [
+                {"mmsi": i, "nmea": f"msg{i}", "x": float(i), "source": "kpler"} for i in range(3)
+            ]
+            (
+                p
+                | beam.Create(rows)
+                | beam.Map(lambda r: beam.window.TimestampedValue(r, window.start))
+                | WritePartitionedParquet(
+                    path=tmpdir,
+                    schema=SCHEMA,
+                    window_size=60,
+                    num_shards=1,
+                    partition=HivePartitionConfig(fields={"source": lambda v: v}),
+                )
+            )
+
+
+def test_expand_time_only():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with TestPipeline() as p:
+            window = make_window(2024, 1, 15, 10)
+            rows = [{"mmsi": i, "nmea": f"msg{i}", "x": float(i)} for i in range(3)]
+            (
+                p
+                | beam.Create(rows)
+                | beam.Map(lambda r: beam.window.TimestampedValue(r, window.start))
+                | WritePartitionedParquet(
+                    path=tmpdir,
+                    schema=SCHEMA,
+                    window_size=60,
+                    num_shards=1,
+                )
+            )


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/PIPELINE-4156

---

## Summary

- Migrates `WritePartitionedParquet` from pipe-nmea into gfw-common as a reusable library transform
- Replaces the hardcoded `source/date/hour` partitioning with a configurable `HivePartitionConfig(fields, prefix, time_granularity)` dataclass.
- Adds `window_size` validation against partition granularity to prevent data silently landing in the wrong partition directory.
- Exports `HivePartitionConfig` and `WritePartitionedParquet` from `gfw.common.beam.transforms`.
- Adds `pyarrow~=18.1` to the `[beam]` optional dependency group.

## Usage

```python
WritePartitionedParquet(
    path="gs://bucket/output",
    schema=pa.schema([...]),
    window_size=300,
    num_shards=6,
    partition=HivePartitionConfig(
        fields={"receiver_type": lambda v: v},
        prefix="event_",
        time_granularity="hour",
    ),
)
```