### PR TITLE
Fix missing python-dateutil core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # Project metadata.
 [project]
 name = "gfw-common"
-version = "0.11.3"
+version = "0.11.4"
 description = "Common place for GFW reusable Python components."
 readme = "README.md"
 license = "Apache-2.0"
@@ -44,6 +44,7 @@ classifiers = [
 ]
 dependencies = [
   "jinja2~=3.1",
+  "python-dateutil~=2.9",
   "pyyaml~=6.0",
   "rich~=14.0",
 ]


### PR DESCRIPTION
## Summary

- Add `python-dateutil~=2.9` to core dependencies in `pyproject.toml`.
- Bump version to `0.11.4`.

## Motivation

`gfw.common.datetime` imports from `dateutil.relativedelta`, but `python-dateutil` was not declared as a core dependency. It was only available transitively via extras (`beam`, `dev`), causing an `ImportError` when `gfw-common` is installed in a minimal environment (e.g. `gfw-ops`) without those extras.

## Test plan

- [x] `pip install gfw-common==0.11.4` in a clean venv with no extras, then `from gfw.common import datetime` succeeds.
- [x] Existing test suite passes.
