### PR TITLE
Add bq_schema_to_pyarrow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # Project metadata.
 [project]
 name = "gfw-common"
-version = "0.12.0"
+version = "0.13.0"
 description = "Common place for GFW reusable Python components."
 readme = "README.md"
 license = "Apache-2.0"
@@ -54,6 +54,7 @@ dependencies = [
 # Google BigQuery
 bq = [
   "google-cloud-bigquery~=3.0",
+  "pyarrow~=18.1",
   "sqlparse==0.5",
 ]
 

--- a/src/gfw/common/bigquery/__init__.py
+++ b/src/gfw/common/bigquery/__init__.py
@@ -17,8 +17,16 @@ Classes
 """
 
 from .helper import BigQueryHelper, QueryResult
+from .schema import BQ_TO_PA, bq_schema_to_pyarrow
 from .table_config import TableConfig
 from .table_description import TableDescription
 
 
-__all__ = ["BigQueryHelper", "QueryResult", "TableConfig", "TableDescription"]
+__all__ = [
+    "BQ_TO_PA",
+    "BigQueryHelper",
+    "QueryResult",
+    "TableConfig",
+    "TableDescription",
+    "bq_schema_to_pyarrow",
+]

--- a/src/gfw/common/bigquery/__init__.py
+++ b/src/gfw/common/bigquery/__init__.py
@@ -17,13 +17,12 @@ Classes
 """
 
 from .helper import BigQueryHelper, QueryResult
-from .schema import BQ_TO_PA, bq_schema_to_pyarrow
+from .schema import bq_schema_to_pyarrow
 from .table_config import TableConfig
 from .table_description import TableDescription
 
 
 __all__ = [
-    "BQ_TO_PA",
     "BigQueryHelper",
     "QueryResult",
     "TableConfig",

--- a/src/gfw/common/bigquery/schema.py
+++ b/src/gfw/common/bigquery/schema.py
@@ -7,7 +7,7 @@ from typing import Any
 import pyarrow as pa
 
 
-BQ_TO_PA: dict[str, pa.DataType] = {
+_BIGQUERY_TO_PYARROW_TYPE_MAPPING: dict[str, pa.DataType] = {
     "STRING": pa.string(),
     "BYTES": pa.binary(),
     "INTEGER": pa.int64(),
@@ -35,8 +35,8 @@ def _convert_bq_field(bq_field: dict[str, Any]) -> pa.Field:
         pa_type: pa.DataType = pa.struct(
             [_convert_bq_field(f) for f in bq_field.get("fields", [])]
         )
-    elif bq_type in BQ_TO_PA:
-        pa_type = BQ_TO_PA[bq_type]
+    elif bq_type in _BIGQUERY_TO_PYARROW_TYPE_MAPPING:
+        pa_type = _BIGQUERY_TO_PYARROW_TYPE_MAPPING[bq_type]
     else:
         raise ValueError(f"Unsupported BigQuery type: {bq_type!r}")
 

--- a/src/gfw/common/bigquery/schema.py
+++ b/src/gfw/common/bigquery/schema.py
@@ -1,0 +1,64 @@
+"""Utilities for converting BigQuery schemas to other formats."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+
+
+BQ_TO_PA: dict[str, pa.DataType] = {
+    "STRING": pa.string(),
+    "BYTES": pa.binary(),
+    "INTEGER": pa.int64(),
+    "INT64": pa.int64(),
+    "FLOAT": pa.float64(),
+    "FLOAT64": pa.float64(),
+    "BOOLEAN": pa.bool_(),
+    "BOOL": pa.bool_(),
+    "TIMESTAMP": pa.timestamp("s"),
+    "DATE": pa.date32(),
+    "DATETIME": pa.timestamp("s"),
+    "TIME": pa.time32("s"),
+    "NUMERIC": pa.decimal128(38, 9),
+    "BIGNUMERIC": pa.decimal256(76, 38),
+    "JSON": pa.string(),
+}
+
+
+def _convert_bq_field(bq_field: dict[str, Any]) -> pa.Field:
+    name = bq_field["name"]
+    bq_type = bq_field["type"].upper()
+    mode = bq_field.get("mode", "NULLABLE").upper()
+
+    if bq_type == "RECORD":
+        pa_type: pa.DataType = pa.struct(
+            [_convert_bq_field(f) for f in bq_field.get("fields", [])]
+        )
+    elif bq_type in BQ_TO_PA:
+        pa_type = BQ_TO_PA[bq_type]
+    else:
+        raise ValueError(f"Unsupported BigQuery type: {bq_type!r}")
+
+    if mode == "REPEATED":
+        pa_type = pa.list_(pa_type)
+
+    return pa.field(name, pa_type, nullable=mode != "REQUIRED")
+
+
+def bq_schema_to_pyarrow(bq_schema: list[dict[str, Any]]) -> pa.Schema:
+    """Convert a BigQuery JSON schema (list of field dicts) to a PyArrow schema.
+
+    Handles nested ``RECORD`` fields (→ :func:`pyarrow.struct`) and ``REPEATED``
+    mode (→ :func:`pyarrow.list_`). Raises :class:`ValueError` for unknown types.
+
+    Args:
+        bq_schema:
+            List of BigQuery field descriptors, each with at minimum ``name``
+            and ``type`` keys. Supports optional ``mode`` (``NULLABLE``,
+            ``REQUIRED``, ``REPEATED``) and ``fields`` for ``RECORD`` types.
+
+    Returns:
+        The equivalent :class:`pyarrow.Schema`.
+    """
+    return pa.schema([_convert_bq_field(f) for f in bq_schema])

--- a/tests/bigquery/test_schema.py
+++ b/tests/bigquery/test_schema.py
@@ -1,0 +1,126 @@
+import pyarrow as pa
+import pytest
+
+from gfw.common.bigquery.schema import bq_schema_to_pyarrow
+
+
+def test_flat_nullable_fields():
+    schema = bq_schema_to_pyarrow(
+        [
+            {"name": "ssvid", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "timestamp", "type": "TIMESTAMP", "mode": "NULLABLE"},
+            {"name": "lat", "type": "FLOAT", "mode": "NULLABLE"},
+            {"name": "count", "type": "INTEGER", "mode": "NULLABLE"},
+            {"name": "flag", "type": "BOOLEAN", "mode": "NULLABLE"},
+        ]
+    )
+    assert schema.field("ssvid").type == pa.string()
+    assert schema.field("timestamp").type == pa.timestamp("s")
+    assert schema.field("lat").type == pa.float64()
+    assert schema.field("count").type == pa.int64()
+    assert schema.field("flag").type == pa.bool_()
+    assert all(schema.field(n).nullable for n in ["ssvid", "timestamp", "lat", "count", "flag"])
+
+
+def test_all_scalar_types():
+    schema = bq_schema_to_pyarrow(
+        [
+            {"name": "a", "type": "STRING"},
+            {"name": "b", "type": "BYTES"},
+            {"name": "c", "type": "INTEGER"},
+            {"name": "d", "type": "INT64"},
+            {"name": "e", "type": "FLOAT"},
+            {"name": "f", "type": "FLOAT64"},
+            {"name": "g", "type": "BOOLEAN"},
+            {"name": "h", "type": "BOOL"},
+            {"name": "i", "type": "TIMESTAMP"},
+            {"name": "j", "type": "DATE"},
+            {"name": "k", "type": "DATETIME"},
+            {"name": "l", "type": "TIME"},
+            {"name": "m", "type": "NUMERIC"},
+            {"name": "n", "type": "BIGNUMERIC"},
+            {"name": "o", "type": "JSON"},
+        ]
+    )
+    assert schema.field("b").type == pa.binary()
+    assert schema.field("c").type == pa.int64()
+    assert schema.field("d").type == pa.int64()
+    assert schema.field("e").type == pa.float64()
+    assert schema.field("f").type == pa.float64()
+    assert schema.field("g").type == pa.bool_()
+    assert schema.field("h").type == pa.bool_()
+    assert schema.field("i").type == pa.timestamp("s")
+    assert schema.field("j").type == pa.date32()
+    assert schema.field("k").type == pa.timestamp("s")
+    assert schema.field("l").type == pa.time32("s")
+    assert schema.field("m").type == pa.decimal128(38, 9)
+    assert schema.field("n").type == pa.decimal256(76, 38)
+    assert schema.field("o").type == pa.string()
+
+
+def test_required_mode_sets_not_nullable():
+    schema = bq_schema_to_pyarrow(
+        [
+            {"name": "id", "type": "STRING", "mode": "REQUIRED"},
+        ]
+    )
+    assert not schema.field("id").nullable
+
+
+def test_repeated_mode_wraps_in_list():
+    schema = bq_schema_to_pyarrow(
+        [
+            {"name": "tags", "type": "STRING", "mode": "REPEATED"},
+        ]
+    )
+    assert schema.field("tags").type == pa.list_(pa.string())
+
+
+def test_record_becomes_struct():
+    schema = bq_schema_to_pyarrow(
+        [
+            {
+                "name": "position",
+                "type": "RECORD",
+                "mode": "NULLABLE",
+                "fields": [
+                    {"name": "lat", "type": "FLOAT"},
+                    {"name": "lon", "type": "FLOAT"},
+                ],
+            }
+        ]
+    )
+    expected = pa.struct([pa.field("lat", pa.float64()), pa.field("lon", pa.float64())])
+    assert schema.field("position").type == expected
+
+
+def test_repeated_record_becomes_list_of_struct():
+    schema = bq_schema_to_pyarrow(
+        [
+            {
+                "name": "waypoints",
+                "type": "RECORD",
+                "mode": "REPEATED",
+                "fields": [
+                    {"name": "lat", "type": "FLOAT"},
+                    {"name": "lon", "type": "FLOAT"},
+                ],
+            }
+        ]
+    )
+    inner = pa.struct([pa.field("lat", pa.float64()), pa.field("lon", pa.float64())])
+    assert schema.field("waypoints").type == pa.list_(inner)
+
+
+def test_default_mode_is_nullable():
+    schema = bq_schema_to_pyarrow([{"name": "x", "type": "STRING"}])
+    assert schema.field("x").nullable
+
+
+def test_unknown_type_raises():
+    with pytest.raises(ValueError, match="Unsupported BigQuery type"):
+        bq_schema_to_pyarrow([{"name": "x", "type": "GEOGRAPHY"}])
+
+
+def test_empty_schema():
+    assert bq_schema_to_pyarrow([]) == pa.schema([])


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/PIPELINE-4228

---

## Summary

- Adds `bq_schema_to_pyarrow` and `BQ_TO_PA` to `gfw.common.bigquery.schema`
- Converts a BigQuery JSON schema (list of field dicts) to a `pyarrow.Schema`; handles `RECORD` (→ `pa.struct`), `REPEATED` mode (→ `pa.list_`), `REQUIRED` nullability, and raises `ValueError` on unknown types
- Adds `pyarrow~=18.1` to the `bq` extra.
- Bumps version to `0.12.1`

## Test plan

- [x] `test_flat_nullable_fields` — common scalar types, nullability
- [x] `test_all_scalar_types` — full `BQ_TO_PA` mapping coverage
- [x] `test_required_mode_sets_not_nullable`
- [x] `test_repeated_mode_wraps_in_list`
- [x] `test_record_becomes_struct` — nested RECORD → `pa.struct`
- [x] `test_repeated_record_becomes_list_of_struct`
- [x] `test_default_mode_is_nullable` — missing `mode` defaults to NULLABLE
- [x] `test_unknown_type_raises` — `ValueError` on unsupported type
- [x] `test_empty_schema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
