### PR TITLE
GFW-COMMON: Add Schema class and BigQueryHelper.fetch_schema

### DIFF
--- a/src/gfw/common/bigquery/__init__.py
+++ b/src/gfw/common/bigquery/__init__.py
@@ -12,12 +12,13 @@ Classes
 
    BigQueryHelper
    QueryResult
+   Schema
    TableConfig
    TableDescription
 """
 
 from .helper import BigQueryHelper, QueryResult
-from .schema import bq_schema_to_pyarrow
+from .schema import Schema
 from .table_config import TableConfig
 from .table_description import TableDescription
 
@@ -25,7 +26,7 @@ from .table_description import TableDescription
 __all__ = [
     "BigQueryHelper",
     "QueryResult",
+    "Schema",
     "TableConfig",
     "TableDescription",
-    "bq_schema_to_pyarrow",
 ]

--- a/src/gfw/common/bigquery/helper.py
+++ b/src/gfw/common/bigquery/helper.py
@@ -14,6 +14,8 @@ from google.cloud import bigquery
 from google.cloud.bigquery import WriteDisposition
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
+from .schema import Schema
+
 
 logger = logging.getLogger(__name__)
 
@@ -422,6 +424,19 @@ class BigQueryHelper:
         self.client.load_table_from_json(
             json_rows=rows, destination=destination, job_config=job_config
         )
+
+    def fetch_schema(self, table: str) -> Schema:
+        """Fetch the schema of a BigQuery table.
+
+        Args:
+            table:
+                Fully-qualified table name (``project.dataset.table``).
+
+        Returns:
+            A :class:`Schema` wrapping the table's schema fields.
+        """
+        bq_table = self.client.get_table(table)
+        return Schema(list(bq_table.schema))
 
     def _create_table_reference(self, table_name: str) -> bigquery.table.TableReference:
         return bigquery.table.TableReference.from_string(

--- a/src/gfw/common/bigquery/schema.py
+++ b/src/gfw/common/bigquery/schema.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
+
+from pathlib import Path
+from typing import Any, Dict
 
 import pyarrow as pa
+
+from google.cloud import bigquery
 
 
 _BIGQUERY_TO_PYARROW_TYPE_MAPPING: dict[str, pa.DataType] = {
@@ -26,39 +31,75 @@ _BIGQUERY_TO_PYARROW_TYPE_MAPPING: dict[str, pa.DataType] = {
 }
 
 
-def _convert_bq_field(bq_field: dict[str, Any]) -> pa.Field:
-    name = bq_field["name"]
-    bq_type = bq_field["type"].upper()
-    mode = bq_field.get("mode", "NULLABLE").upper()
-
-    if bq_type == "RECORD":
-        pa_type: pa.DataType = pa.struct(
-            [_convert_bq_field(f) for f in bq_field.get("fields", [])]
-        )
-    elif bq_type in _BIGQUERY_TO_PYARROW_TYPE_MAPPING:
-        pa_type = _BIGQUERY_TO_PYARROW_TYPE_MAPPING[bq_type]
+def _convert_schema_field(field: bigquery.SchemaField) -> pa.Field:
+    if field.field_type == "RECORD":
+        pa_type: pa.DataType = pa.struct([_convert_schema_field(f) for f in field.fields])
+    elif field.field_type in _BIGQUERY_TO_PYARROW_TYPE_MAPPING:
+        pa_type = _BIGQUERY_TO_PYARROW_TYPE_MAPPING[field.field_type]
     else:
-        raise ValueError(f"Unsupported BigQuery type: {bq_type!r}")
+        raise ValueError(f"Unsupported BigQuery type: {field.field_type!r}")
 
-    if mode == "REPEATED":
+    if field.mode == "REPEATED":
         pa_type = pa.list_(pa_type)
 
-    return pa.field(name, pa_type, nullable=mode != "REQUIRED")
+    return pa.field(field.name, pa_type, nullable=field.mode != "REQUIRED")
 
 
-def bq_schema_to_pyarrow(bq_schema: list[dict[str, Any]]) -> pa.Schema:
-    """Convert a BigQuery JSON schema (list of field dicts) to a PyArrow schema.
+class Schema:
+    """A BigQuery schema with conversion utilities.
 
-    Handles nested ``RECORD`` fields (→ :func:`pyarrow.struct`) and ``REPEATED``
-    mode (→ :func:`pyarrow.list_`). Raises :class:`ValueError` for unknown types.
+    Wraps a list of :class:`~google.cloud.bigquery.SchemaField` objects and provides
+    methods to convert to other formats.
 
     Args:
-        bq_schema:
-            List of BigQuery field descriptors, each with at minimum ``name``
-            and ``type`` keys. Supports optional ``mode`` (``NULLABLE``,
-            ``REQUIRED``, ``REPEATED``) and ``fields`` for ``RECORD`` types.
-
-    Returns:
-        The equivalent :class:`pyarrow.Schema`.
+        fields:
+            List of BigQuery schema fields.
     """
-    return pa.schema([_convert_bq_field(f) for f in bq_schema])
+
+    def __init__(self, fields: list[bigquery.SchemaField]) -> None:
+        self._fields = fields
+
+    @classmethod
+    def from_dicts(cls, dicts: list[dict[str, Any]]) -> Schema:
+        """Construct a :class:`Schema` from a list of BigQuery field descriptor dicts.
+
+        Args:
+            dicts:
+                List of BigQuery field descriptors, each with at minimum ``name``
+                and ``type`` keys. Supports optional ``mode`` and ``fields`` for
+                nested ``RECORD`` types.
+
+        Returns:
+            A :class:`Schema` wrapping the parsed fields.
+        """
+        return cls([bigquery.SchemaField.from_api_repr(f) for f in dicts])
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> Schema:
+        """Load a BigQuery JSON schema file and return a :class:`Schema`.
+
+        Args:
+            path:
+                Path to a JSON file containing a list of BigQuery field descriptors.
+
+        Returns:
+            A :class:`Schema` wrapping the parsed fields.
+        """
+        return cls.from_dicts(json.loads(Path(path).read_text()))
+
+    @property
+    def fields(self) -> list[bigquery.SchemaField]:
+        """The raw BigQuery :class:`~google.cloud.bigquery.SchemaField` list."""
+        return self._fields
+
+    def as_dicts(self) -> list[Dict[str, Any]]:
+        """Return the schema as a list of BigQuery field descriptor dicts.
+
+        Useful when passing a schema to interfaces that expect the JSON dict
+        format (e.g. :class:`~gfw.common.beam.transforms.bigquery.WriteToBigQueryWrapper`).
+        """
+        return [f.to_api_repr() for f in self._fields]
+
+    def as_pyarrow(self) -> pa.Schema:
+        """Convert to a :class:`pyarrow.Schema`."""
+        return pa.schema([_convert_schema_field(f) for f in self._fields])

--- a/tests/bigquery/test_helper.py
+++ b/tests/bigquery/test_helper.py
@@ -1,11 +1,13 @@
 from unittest import mock
 
+import pyarrow as pa
 import pytest
 
 from google.cloud import bigquery
-from google.cloud.bigquery import WriteDisposition
+from google.cloud.bigquery import SchemaField, WriteDisposition
 
 from gfw.common.bigquery.helper import BigQueryHelper, QueryResult
+from gfw.common.bigquery.schema import Schema
 
 
 def test_mocked_factory_creates_mock():
@@ -316,6 +318,34 @@ def test_load_from_json_with_partitioning():
     assert isinstance(job_config.time_partitioning, bigquery.table.TimePartitioning)
     assert job_config.time_partitioning.type_ == "HOUR"
     assert job_config.time_partitioning.field == "id"
+
+
+def test_fetch_schema_returns_schema_object():
+    helper = BigQueryHelper.mocked(project="test")
+    fields = [
+        SchemaField("ssvid", "STRING", mode="NULLABLE"),
+        SchemaField("lat", "FLOAT", mode="REQUIRED"),
+    ]
+    helper.client.get_table.return_value.schema = fields
+
+    result = helper.fetch_schema("proj.ds.table")
+
+    helper.client.get_table.assert_called_once_with("proj.ds.table")
+    assert isinstance(result, Schema)
+    assert result.fields == fields
+
+
+def test_fetch_schema_as_pyarrow():
+    helper = BigQueryHelper.mocked(project="test")
+    helper.client.get_table.return_value.schema = [
+        SchemaField("ssvid", "STRING", mode="NULLABLE"),
+        SchemaField("lat", "FLOAT", mode="REQUIRED"),
+    ]
+
+    pa_schema = helper.fetch_schema("proj.ds.table").as_pyarrow()
+
+    assert pa_schema.field("ssvid").type == pa.string()
+    assert not pa_schema.field("lat").nullable
 
 
 @pytest.mark.integration

--- a/tests/bigquery/test_schema.py
+++ b/tests/bigquery/test_schema.py
@@ -1,11 +1,13 @@
 import pyarrow as pa
 import pytest
 
-from gfw.common.bigquery.schema import bq_schema_to_pyarrow
+from google.cloud.bigquery import SchemaField
+
+from gfw.common.bigquery.schema import Schema
 
 
 def test_flat_nullable_fields():
-    schema = bq_schema_to_pyarrow(
+    schema = Schema.from_dicts(
         [
             {"name": "ssvid", "type": "STRING", "mode": "NULLABLE"},
             {"name": "timestamp", "type": "TIMESTAMP", "mode": "NULLABLE"},
@@ -13,7 +15,7 @@ def test_flat_nullable_fields():
             {"name": "count", "type": "INTEGER", "mode": "NULLABLE"},
             {"name": "flag", "type": "BOOLEAN", "mode": "NULLABLE"},
         ]
-    )
+    ).as_pyarrow()
     assert schema.field("ssvid").type == pa.string()
     assert schema.field("timestamp").type == pa.timestamp("s")
     assert schema.field("lat").type == pa.float64()
@@ -23,7 +25,7 @@ def test_flat_nullable_fields():
 
 
 def test_all_scalar_types():
-    schema = bq_schema_to_pyarrow(
+    schema = Schema.from_dicts(
         [
             {"name": "a", "type": "STRING"},
             {"name": "b", "type": "BYTES"},
@@ -41,7 +43,7 @@ def test_all_scalar_types():
             {"name": "n", "type": "BIGNUMERIC"},
             {"name": "o", "type": "JSON"},
         ]
-    )
+    ).as_pyarrow()
     assert schema.field("b").type == pa.binary()
     assert schema.field("c").type == pa.int64()
     assert schema.field("d").type == pa.int64()
@@ -59,25 +61,25 @@ def test_all_scalar_types():
 
 
 def test_required_mode_sets_not_nullable():
-    schema = bq_schema_to_pyarrow(
+    schema = Schema.from_dicts(
         [
             {"name": "id", "type": "STRING", "mode": "REQUIRED"},
         ]
-    )
+    ).as_pyarrow()
     assert not schema.field("id").nullable
 
 
 def test_repeated_mode_wraps_in_list():
-    schema = bq_schema_to_pyarrow(
+    schema = Schema.from_dicts(
         [
             {"name": "tags", "type": "STRING", "mode": "REPEATED"},
         ]
-    )
+    ).as_pyarrow()
     assert schema.field("tags").type == pa.list_(pa.string())
 
 
 def test_record_becomes_struct():
-    schema = bq_schema_to_pyarrow(
+    schema = Schema.from_dicts(
         [
             {
                 "name": "position",
@@ -89,13 +91,13 @@ def test_record_becomes_struct():
                 ],
             }
         ]
-    )
+    ).as_pyarrow()
     expected = pa.struct([pa.field("lat", pa.float64()), pa.field("lon", pa.float64())])
     assert schema.field("position").type == expected
 
 
 def test_repeated_record_becomes_list_of_struct():
-    schema = bq_schema_to_pyarrow(
+    schema = Schema.from_dicts(
         [
             {
                 "name": "waypoints",
@@ -107,20 +109,87 @@ def test_repeated_record_becomes_list_of_struct():
                 ],
             }
         ]
-    )
+    ).as_pyarrow()
     inner = pa.struct([pa.field("lat", pa.float64()), pa.field("lon", pa.float64())])
     assert schema.field("waypoints").type == pa.list_(inner)
 
 
 def test_default_mode_is_nullable():
-    schema = bq_schema_to_pyarrow([{"name": "x", "type": "STRING"}])
+    schema = Schema.from_dicts([{"name": "x", "type": "STRING"}]).as_pyarrow()
     assert schema.field("x").nullable
 
 
 def test_unknown_type_raises():
     with pytest.raises(ValueError, match="Unsupported BigQuery type"):
-        bq_schema_to_pyarrow([{"name": "x", "type": "GEOGRAPHY"}])
+        Schema.from_dicts([{"name": "x", "type": "GEOGRAPHY"}]).as_pyarrow()
 
 
 def test_empty_schema():
-    assert bq_schema_to_pyarrow([]) == pa.schema([])
+    assert Schema.from_dicts([]).as_pyarrow() == pa.schema([])
+
+
+def test_from_json(tmp_path):
+    import json
+
+    schema_file = tmp_path / "schema.json"
+    schema_file.write_text(
+        json.dumps(
+            [
+                {"name": "ssvid", "type": "STRING", "mode": "NULLABLE"},
+                {"name": "lat", "type": "FLOAT", "mode": "REQUIRED"},
+            ]
+        )
+    )
+    schema = Schema.from_json(schema_file).as_pyarrow()
+    assert schema.field("ssvid").type == pa.string()
+    assert not schema.field("lat").nullable
+
+
+# --- Schema class ---
+
+
+def _make_fields():
+    return [
+        SchemaField("ssvid", "STRING", mode="NULLABLE"),
+        SchemaField("timestamp", "TIMESTAMP", mode="NULLABLE"),
+        SchemaField("lat", "FLOAT", mode="REQUIRED"),
+    ]
+
+
+def test_schema_fields_returns_original():
+    fields = _make_fields()
+    schema = Schema(fields)
+    assert schema.fields is fields
+
+
+def test_schema_as_dicts():
+    fields = _make_fields()
+    dicts = Schema(fields).as_dicts()
+    assert [d["name"] for d in dicts] == ["ssvid", "timestamp", "lat"]
+    assert dicts[0]["type"] == "STRING"
+    assert dicts[2]["mode"] == "REQUIRED"
+
+
+def test_schema_as_pyarrow_flat():
+    schema = Schema(_make_fields())
+    pa_schema = schema.as_pyarrow()
+    assert pa_schema.field("ssvid").type == pa.string()
+    assert pa_schema.field("timestamp").type == pa.timestamp("s")
+    assert not pa_schema.field("lat").nullable
+
+
+def test_schema_as_pyarrow_nested_record():
+    fields = [
+        SchemaField(
+            "position",
+            "RECORD",
+            mode="NULLABLE",
+            fields=[
+                SchemaField("lat", "FLOAT"),
+                SchemaField("lon", "FLOAT"),
+            ],
+        )
+    ]
+    pa_schema = Schema(fields).as_pyarrow()
+    expected = pa.struct([pa.field("lat", pa.float64()), pa.field("lon", pa.float64())])
+    assert pa_schema.field("position").type == expected


### PR DESCRIPTION
## Summary

- Adds `Schema`, a BigQuery schema wrapper with conversion utilities, replacing the removed `bq_schema_to_pyarrow` function
- Adds `BigQueryHelper.fetch_schema(table) -> Schema` to retrieve a table's schema directly from BigQuery

### `Schema` API

| Constructor / method | Description |
|---|---|
| `Schema(fields)` | Wrap an existing `list[SchemaField]` |
| `Schema.from_dicts(dicts)` | Parse from a list of BQ JSON field descriptor dicts |
| `Schema.from_json(path)` | Load from a BQ JSON schema file |
| `schema.fields` | The raw `list[SchemaField]` |
| `as_dicts()` | Return `list[dict]` for interfaces like `WriteToBigQueryWrapper` |
| `as_pyarrow()` | Convert to `pa.Schema` directly from `SchemaField` objects (no intermediate dicts) |

### Motivation

`bq_schema_to_pyarrow` took a `list[dict]` and converted to `pa.Schema` via an internal dict representation. `Schema` makes all schema sources (BQ table, JSON file, inline `SchemaField` list) converge to a single type with explicit, named conversion methods — no implicit format assumptions.

`bq_schema_to_pyarrow` is removed; use `Schema.from_dicts(dicts).as_pyarrow()` instead.
