### PR TITLE
Allow injecting a custom Parquet sink factory into WritePartitionedParquet

### DIFF
--- a/src/gfw/common/beam/transforms/__init__.py
+++ b/src/gfw/common/beam/transforms/__init__.py
@@ -39,6 +39,7 @@ Extra classes useful for testing
    :template: custom-class-template.rst
    :signatures: none
 
+   FakeParquetSink
    FakeReadFromPubSub
    FakeWriteToBigQuery
 
@@ -47,7 +48,7 @@ Extra classes useful for testing
 from .apply_sliding_windows import ApplySlidingWindows
 from .bigquery import FakeWriteToBigQuery, WriteToBigQueryWrapper
 from .group_by import GroupBy
-from .parquet import HivePartitionConfig, WritePartitionedParquet
+from .parquet import FakeParquetSink, HivePartitionConfig, WritePartitionedParquet
 from .pubsub import FakeReadFromPubSub, ReadAndDecodeFromPubSub
 from .read_from_bigquery import ReadFromBigQuery
 from .read_from_json import ReadFromJson
@@ -58,6 +59,7 @@ from .write_to_json import WriteToJson
 
 __all__ = [
     "ApplySlidingWindows",
+    "FakeParquetSink",
     "FakeReadFromPubSub",
     "FakeWriteToBigQuery",
     "GroupBy",

--- a/src/gfw/common/beam/transforms/__init__.py
+++ b/src/gfw/common/beam/transforms/__init__.py
@@ -42,13 +42,14 @@ Extra classes useful for testing
    FakeParquetSink
    FakeReadFromPubSub
    FakeWriteToBigQuery
+   ParquetSink
 
 """
 
 from .apply_sliding_windows import ApplySlidingWindows
 from .bigquery import FakeWriteToBigQuery, WriteToBigQueryWrapper
 from .group_by import GroupBy
-from .parquet import FakeParquetSink, HivePartitionConfig, WritePartitionedParquet
+from .parquet import FakeParquetSink, HivePartitionConfig, ParquetSink, WritePartitionedParquet
 from .pubsub import FakeReadFromPubSub, ReadAndDecodeFromPubSub
 from .read_from_bigquery import ReadFromBigQuery
 from .read_from_json import ReadFromJson
@@ -64,6 +65,7 @@ __all__ = [
     "FakeWriteToBigQuery",
     "GroupBy",
     "HivePartitionConfig",
+    "ParquetSink",
     "ReadAndDecodeFromPubSub",
     "ReadFromBigQuery",
     "ReadFromJson",

--- a/src/gfw/common/beam/transforms/parquet.py
+++ b/src/gfw/common/beam/transforms/parquet.py
@@ -122,6 +122,12 @@ class WritePartitionedParquet(beam.PTransform):
         partition:
             Hive partition layout. Defaults to hourly time-only partitioning
             with ``"event_"`` prefix. See :class:`HivePartitionConfig`.
+
+        sink_factory:
+            A callable ``(schema, codec) -> FileSink`` used to create the sink
+            for each output file. Defaults to :class:`_ParquetSink`. Inject
+            :class:`FakeParquetSink` to bypass GCS writes in tests while still
+            exercising windowing, partitioning, and file-naming logic.
     """
 
     def __init__(
@@ -135,6 +141,7 @@ class WritePartitionedParquet(beam.PTransform):
         codec: str = "snappy",
         file_suffix: str = ".parquet",
         partition: HivePartitionConfig | None = None,
+        sink_factory: Callable[..., FileSink] | None = None,
     ) -> None:
         self._path = path
         self._schema = schema
@@ -145,6 +152,7 @@ class WritePartitionedParquet(beam.PTransform):
         self._codec = codec
         self._file_suffix = file_suffix
         self._partition = partition or HivePartitionConfig()
+        self._sink_factory = sink_factory or _ParquetSink
         self._validate()
 
     def _validate(self) -> None:
@@ -172,7 +180,7 @@ class WritePartitionedParquet(beam.PTransform):
             >> fileio.WriteToFiles(
                 path=self._path,
                 destination=_partition_path,
-                sink=lambda dest: _ParquetSink(schema=self._schema, codec=self._codec),
+                sink=lambda dest: self._sink_factory(schema=self._schema, codec=self._codec),
                 file_naming=_safe_filenaming(suffix=self._file_suffix),
                 shards=self._num_shards,
                 # The following ensures we always use sharded destinations.
@@ -265,6 +273,28 @@ class _ParquetSink(FileSink):
             self._buffer = None  # type: ignore[assignment]
             self._writer.close()
             self._writer = None
+
+
+class FakeParquetSink(FileSink):
+    """A no-op :class:`~apache_beam.io.fileio.FileSink` for testing.
+
+    Accepts the same constructor signature as :class:`_ParquetSink` but
+    discards all data without writing. Inject via ``sink_factory`` on
+    :class:`WritePartitionedParquet` to exercise windowing, partitioning,
+    and file-naming logic without touching the filesystem.
+    """
+
+    def __init__(self, schema: pa.Schema, codec: str = "snappy") -> None:
+        pass
+
+    def open(self, fh: BinaryIO) -> None:  # noqa: D102
+        pass
+
+    def write(self, element: tuple[str, Row]) -> None:  # noqa: D102
+        pass
+
+    def flush(self) -> None:  # noqa: D102
+        pass
 
 
 def _safe_filenaming(suffix: Any = None) -> Callable[..., str]:

--- a/src/gfw/common/beam/transforms/parquet.py
+++ b/src/gfw/common/beam/transforms/parquet.py
@@ -1,5 +1,7 @@
 """PTransform for writing hive-partitioned Parquet files."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Any, BinaryIO, Callable, Iterable, Literal
 
@@ -125,7 +127,7 @@ class WritePartitionedParquet(beam.PTransform):
 
         sink_factory:
             A callable ``(schema, codec) -> FileSink`` used to create the sink
-            for each output file. Defaults to :class:`_ParquetSink`. Inject
+            for each output file. Defaults to :class:`ParquetSink`. Inject
             :class:`FakeParquetSink` to bypass GCS writes in tests while still
             exercising windowing, partitioning, and file-naming logic.
     """
@@ -141,7 +143,7 @@ class WritePartitionedParquet(beam.PTransform):
         codec: str = "snappy",
         file_suffix: str = ".parquet",
         partition: HivePartitionConfig | None = None,
-        sink_factory: Callable[..., FileSink] | None = None,
+        sink_factory: Callable[..., ParquetSink] | None = None,
     ) -> None:
         self._path = path
         self._schema = schema
@@ -152,7 +154,7 @@ class WritePartitionedParquet(beam.PTransform):
         self._codec = codec
         self._file_suffix = file_suffix
         self._partition = partition or HivePartitionConfig()
-        self._sink_factory = sink_factory or _ParquetSink
+        self._sink_factory = sink_factory or ParquetSink
         self._validate()
 
     def _validate(self) -> None:
@@ -240,7 +242,7 @@ class _AddPartitionKey(beam.DoFn):
         yield path, element
 
 
-class _ParquetSink(FileSink):
+class ParquetSink(FileSink):
     """A :class:`~apache_beam.io.fileio.FileSink` that buffers rows and flushes as one row group.
 
     Args:
@@ -253,6 +255,7 @@ class _ParquetSink(FileSink):
         self._codec = codec
 
     def open(self, fh: BinaryIO) -> None:
+        """Open the Parquet writer and initialise the row buffer."""
         self._writer = pa.parquet.ParquetWriter(
             fh,
             self._schema,
@@ -261,10 +264,12 @@ class _ParquetSink(FileSink):
         self._buffer: list[Row] = []
 
     def write(self, element: tuple[str, Row]) -> None:
+        """Buffer one keyed row for writing."""
         _, row = element
         self._buffer.append(row)
 
     def flush(self) -> None:
+        """Write all buffered rows as a single row group and close the writer."""
         try:
             if self._buffer:
                 batch = pa.RecordBatch.from_pylist(self._buffer, schema=self._schema)
@@ -275,11 +280,10 @@ class _ParquetSink(FileSink):
             self._writer = None
 
 
-class FakeParquetSink(FileSink):
-    """A no-op :class:`~apache_beam.io.fileio.FileSink` for testing.
+class FakeParquetSink(ParquetSink):
+    """A no-op :class:`ParquetSink` for testing.
 
-    Accepts the same constructor signature as :class:`_ParquetSink` but
-    discards all data without writing. Inject via ``sink_factory`` on
+    Discards all data without writing. Inject via ``sink_factory`` on
     :class:`WritePartitionedParquet` to exercise windowing, partitioning,
     and file-naming logic without touching the filesystem.
     """

--- a/tests/beam/transforms/test_parquet.py
+++ b/tests/beam/transforms/test_parquet.py
@@ -18,6 +18,7 @@ from apache_beam.transforms.window import IntervalWindow
 from apache_beam.utils.timestamp import Timestamp
 
 from gfw.common.beam.transforms.parquet import (
+    FakeParquetSink,
     HivePartitionConfig,
     WritePartitionedParquet,
     _AddPartitionKey,
@@ -471,6 +472,39 @@ def test_window_size_equal_to_granularity_is_valid():
     )
 
 
+def test_default_sink_factory_is_parquet_sink():
+    t = WritePartitionedParquet(path="gs://b/p", schema=SCHEMA)
+    assert t._sink_factory is _ParquetSink
+
+
+def test_custom_sink_factory_stored():
+    t = WritePartitionedParquet(path="gs://b/p", schema=SCHEMA, sink_factory=FakeParquetSink)
+    assert t._sink_factory is FakeParquetSink
+
+
+# ---------------------------------------------------------------------------
+# FakeParquetSink
+# ---------------------------------------------------------------------------
+
+
+def test_fake_sink_open_is_noop():
+    s = FakeParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+
+
+def test_fake_sink_write_is_noop():
+    s = FakeParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    s.write(make_keyed({"mmsi": 1, "nmea": "x", "x": 1.0}))
+
+
+def test_fake_sink_flush_is_noop():
+    s = FakeParquetSink(schema=SCHEMA)
+    s.open(make_fh())
+    s.write(make_keyed({"mmsi": 1, "nmea": "x", "x": 1.0}))
+    s.flush()
+
+
 # ---------------------------------------------------------------------------
 # WritePartitionedParquet — expand integration
 # ---------------------------------------------------------------------------
@@ -511,5 +545,27 @@ def test_expand_time_only():
                     schema=SCHEMA,
                     window_size=60,
                     num_shards=1,
+                )
+            )
+
+
+def test_expand_with_fake_sink():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with TestPipeline() as p:
+            window = make_window(2024, 1, 15, 10)
+            rows = [
+                {"mmsi": i, "nmea": f"msg{i}", "x": float(i), "source": "kpler"} for i in range(3)
+            ]
+            (
+                p
+                | beam.Create(rows)
+                | beam.Map(lambda r: beam.window.TimestampedValue(r, window.start))
+                | WritePartitionedParquet(
+                    path=tmpdir,
+                    schema=SCHEMA,
+                    window_size=60,
+                    num_shards=1,
+                    partition=HivePartitionConfig(fields={"source": lambda v: v}),
+                    sink_factory=FakeParquetSink,
                 )
             )

--- a/tests/beam/transforms/test_parquet.py
+++ b/tests/beam/transforms/test_parquet.py
@@ -20,9 +20,9 @@ from apache_beam.utils.timestamp import Timestamp
 from gfw.common.beam.transforms.parquet import (
     FakeParquetSink,
     HivePartitionConfig,
+    ParquetSink,
     WritePartitionedParquet,
     _AddPartitionKey,
-    _ParquetSink,
     _safe_filenaming,
 )
 
@@ -246,27 +246,27 @@ def test_safe_filenaming_no_suffix_no_colons():
 
 
 # ---------------------------------------------------------------------------
-# _ParquetSink — construction
+# ParquetSink — construction
 # ---------------------------------------------------------------------------
 
 
 def test_sink_stores_schema_and_codec():
-    s = _ParquetSink(schema=SCHEMA, codec="zstd")
+    s = ParquetSink(schema=SCHEMA, codec="zstd")
     assert s._schema == SCHEMA
     assert s._codec == "zstd"
 
 
 def test_sink_default_codec():
-    assert _ParquetSink(schema=SCHEMA)._codec == "snappy"
+    assert ParquetSink(schema=SCHEMA)._codec == "snappy"
 
 
 # ---------------------------------------------------------------------------
-# _ParquetSink — open
+# ParquetSink — open
 # ---------------------------------------------------------------------------
 
 
 def test_open_creates_writer_and_empty_buffer():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     s.open(make_fh())
     assert isinstance(s._writer, pa.parquet.ParquetWriter)
     assert s._buffer == []
@@ -274,7 +274,7 @@ def test_open_creates_writer_and_empty_buffer():
 
 
 def test_open_passes_codec_to_writer():
-    s = _ParquetSink(schema=SCHEMA, codec="gzip")
+    s = ParquetSink(schema=SCHEMA, codec="gzip")
     fh = make_fh()
     with patch("pyarrow.parquet.ParquetWriter") as mock_cls:
         mock_cls.return_value = MagicMock()
@@ -283,12 +283,12 @@ def test_open_passes_codec_to_writer():
 
 
 # ---------------------------------------------------------------------------
-# _ParquetSink — write
+# ParquetSink — write
 # ---------------------------------------------------------------------------
 
 
 def test_write_appends_row():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     s.open(make_fh())
     row = {"mmsi": 1, "nmea": "x", "x": 1.0}
     s.write(make_keyed(row))
@@ -297,7 +297,7 @@ def test_write_appends_row():
 
 
 def test_write_ignores_partition_key():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     s.open(make_fh())
     row = {"mmsi": 1, "nmea": "x", "x": None}
     s.write(("some/partition/path/", row))
@@ -306,7 +306,7 @@ def test_write_ignores_partition_key():
 
 
 def test_write_accumulates_multiple_rows():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     s.open(make_fh())
     rows = [{"mmsi": i, "nmea": f"m{i}", "x": float(i)} for i in range(5)]
     for row in rows:
@@ -316,12 +316,12 @@ def test_write_accumulates_multiple_rows():
 
 
 # ---------------------------------------------------------------------------
-# _ParquetSink — flush: normal path
+# ParquetSink — flush: normal path
 # ---------------------------------------------------------------------------
 
 
 def test_flush_writes_correct_data():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     fh = make_fh()
     s.open(fh)
     for row in [{"mmsi": 1, "nmea": "msg1", "x": 1.0}, {"mmsi": 2, "nmea": "msg2", "x": 2.0}]:
@@ -333,7 +333,7 @@ def test_flush_writes_correct_data():
 
 
 def test_flush_empty_buffer_does_not_raise():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     s.open(make_fh())
     s.flush()
     assert s._writer is None
@@ -341,7 +341,7 @@ def test_flush_empty_buffer_does_not_raise():
 
 
 def test_flush_nulls_writer_and_buffer():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     s.open(make_fh())
     s.write(make_keyed({"mmsi": 1, "nmea": "x", "x": None}))
     s.flush()
@@ -350,7 +350,7 @@ def test_flush_nulls_writer_and_buffer():
 
 
 def test_flush_handles_null_values():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     fh = make_fh()
     s.open(fh)
     s.write(make_keyed({"mmsi": None, "nmea": "msg", "x": None}))
@@ -361,7 +361,7 @@ def test_flush_handles_null_values():
 
 
 def test_flush_produces_single_row_group():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     fh = make_fh()
     s.open(fh)
     for i in range(100):
@@ -372,12 +372,12 @@ def test_flush_produces_single_row_group():
 
 
 # ---------------------------------------------------------------------------
-# _ParquetSink — flush: exception safety
+# ParquetSink — flush: exception safety
 # ---------------------------------------------------------------------------
 
 
 def test_flush_closes_writer_if_write_batch_raises():
-    s = _ParquetSink(schema=SCHEMA)
+    s = ParquetSink(schema=SCHEMA)
     s.open(make_fh())
     s.write(make_keyed({"mmsi": 1, "nmea": "x", "x": 1.0}))
     mock_writer = MagicMock()
@@ -394,7 +394,7 @@ def test_flush_closes_writer_if_write_batch_raises():
 
 def test_flush_closes_writer_if_from_pylist_raises():
     bad_schema = pa.schema([pa.field("mmsi", pa.int64())])
-    s = _ParquetSink(schema=bad_schema, codec="snappy")
+    s = ParquetSink(schema=bad_schema, codec="snappy")
     s.open(make_fh())
     s._buffer = [{"mmsi": "not-an-int"}]
     mock_writer = MagicMock()
@@ -474,7 +474,7 @@ def test_window_size_equal_to_granularity_is_valid():
 
 def test_default_sink_factory_is_parquet_sink():
     t = WritePartitionedParquet(path="gs://b/p", schema=SCHEMA)
-    assert t._sink_factory is _ParquetSink
+    assert t._sink_factory is ParquetSink
 
 
 def test_custom_sink_factory_stored():


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/PIPELINE-4231

---

## Summary

- Adds `sink_factory` parameter to `WritePartitionedParquet` so the file-writing layer can be injected without replacing the entire transform — windowing, partitioning, and file-naming logic are still exercised.
- Adds `ParquetSink` (formerly `_ParquetSink`) as a public extension point for custom Parquet writing strategies.
- Adds `FakeParquetSink`, a no-op `ParquetSink` subclass that discards all data, analogous to `FakeReadFromBigQuery`.

### Design

`sink_factory` is typed as `Callable[..., ParquetSink]` — not the broader `FileSink` — to make clear that only Parquet-compatible sinks belong here. `FakeParquetSink` subclasses `ParquetSink` rather than `FileSink` for the same reason.

The fake does nothing by design: if you want to verify written data, use the real `ParquetSink` with a local temp path (as the existing expand integration tests already do). The fake's value is speed and focus — it tests pipeline logic without I/O overhead.

## Test plan

- [x] `test_default_sink_factory_is_parquet_sink` — default wiring is correct
- [x] `test_custom_sink_factory_stored` — injection is stored
- [x] `test_fake_sink_open/write/flush_is_noop` — fake is safe to call
- [x] `test_expand_with_fake_sink` — full pipeline integration with `FakeParquetSink` and a source partition
