### PR TITLE
FIX: Don't inject CLI unknown_args keys into config when allow_unknown=False

### DIFF
--- a/src/gfw/common/cli/cli.py
+++ b/src/gfw/common/cli/cli.py
@@ -257,8 +257,9 @@ class CLI:
 
         config = DeepChainMap(cli_args, config_file_args, defaults_args).to_dict()
 
-        config[self._KEY_UNKNOWN_UNPARSED_ARGS] = unknown_unparsed_args
-        config[self._KEY_UNKNOWN_PARSED_ARGS] = unknown_parsed_args
+        if self._allow_unknown:
+            config[self._KEY_UNKNOWN_UNPARSED_ARGS] = unknown_unparsed_args
+            config[self._KEY_UNKNOWN_PARSED_ARGS] = unknown_parsed_args
 
         self._validate_required_args(command, config)
 


### PR DESCRIPTION
When allow_unknown=False, unknown_parsed_args and unknown_unparsed_args are always empty, so adding them to the config dict is misleading and forces callers that spread **config as kwargs to declare those parameters unnecessarily.